### PR TITLE
Attempted to resolve issue #202

### DIFF
--- a/src/Model/Search/PersonSearchListItem.php
+++ b/src/Model/Search/PersonSearchListItem.php
@@ -58,6 +58,26 @@ class PersonSearchListItem
         return $instance;
     }
 
+    /**
+     * @param Parser\Search\PersonSearchPersonParser $parser
+     *
+     * @return PersonSearchListItem
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    public static function fromPersonParser(Parser\Search\PersonSearchPersonParser $parser): self
+    {
+        $instance = new self();
+
+        $instance->url = $parser->getUrl();
+        $instance->malId = \Jikan\Helper\Parser::idFromUrl($instance->url);
+        $instance->imageUrl = $parser->getImageUrl();
+        $instance->name = $parser->getName();
+        $instance->alternativeNames = $parser->getAlternativeNames();
+
+        return $instance;
+    }
+
 
     /**
      * @return int

--- a/src/Parser/Search/PersonSearchParser.php
+++ b/src/Parser/Search/PersonSearchParser.php
@@ -46,7 +46,7 @@ class PersonSearchParser
      */
     public function getResults(): array
     {
-        return $this->crawler
+        $data = $this->crawler
             ->filterXPath('//div[@id="content"]/table/tr[1]')
             ->nextAll()
             ->each(
@@ -54,6 +54,18 @@ class PersonSearchParser
                     return (new PersonSearchListItemParser($c))->getModel();
                 }
             );
+
+        // If only a single result is found, the $data array will be empty.
+        if (empty($data)) {
+            $data = $this->crawler
+                ->each(
+                    function (Crawler $c) {
+                        return (new PersonSearchPersonParser($c))->getModel();
+                    }
+                );
+        }
+            
+        return $data;
     }
 
     /**

--- a/src/Parser/Search/PersonSearchPersonParser.php
+++ b/src/Parser/Search/PersonSearchPersonParser.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Jikan\Parser\Search;
+
+use Jikan\Helper\Constants;
+use Jikan\Helper\JString;
+use Jikan\Helper\Parser;
+use Jikan\Model\Common\MalUrl;
+use Jikan\Model\Search\PersonSearchListItem;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class PersonSearchListItemParser
+ *
+ * @package Jikan\Parser
+ */
+class PersonSearchPersonParser
+{
+    /**
+     * @var Crawler
+     */
+    private $crawler;
+
+    /**
+     * PersonSearchParser constructor.
+     *
+     * @param Crawler $crawler
+     */
+    public function __construct(Crawler $crawler)
+    {
+        $this->crawler = $crawler;
+    }
+
+    /**
+     * @return PersonSearchListItem
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    public function getModel(): PersonSearchListItem
+    {
+        return PersonSearchListItem::fromPersonParser($this);
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getUrl(): string
+    {
+        return $this->crawler->filterXPath('//meta[@property=\'og:url\']')->attr('content');
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getName(): string
+    {
+        return JString::cleanse($this->crawler->filterXPath('//meta[@property=\'og:title\']')->attr('content'));
+    }
+
+    /**
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public function getAlternativeNames(): array
+    {
+        $node = $this->crawler
+            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]/div/span[text()="Alternate names:"]');
+
+        if (!$node->count()) {
+            return [];
+        }
+
+        $names = explode(
+            ',',
+            str_replace($node->text(), '', $node->parents()->text())
+        );
+
+        foreach ($names as &$name) {
+            $name = JString::cleanse($name);
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getImageUrl(): string
+    {
+        return $this->crawler->filterXPath('//meta[@property=\'og:image\']')->attr('content');
+    }
+}


### PR DESCRIPTION
Attempted to resolve issue #202  in which searching for a Person and results in an empty array when only a single result is found.

The fix was accomplished by checking for an empty result after the search is completed in Search/PersonSearchParser.php, then crawling the page again to return the applicable person data - the same data that is returned from normal search data.

A new class, Search/PersonSearchPersonParser.php was created to handle pulling only the typical search results data from the person's page.