### PR TITLE
Fixed parseDateDMY parsing into the wrong format

### DIFF
--- a/src/Helper/Parser.php
+++ b/src/Helper/Parser.php
@@ -132,7 +132,7 @@ class Parser
 
         $date = str_replace('??', '01', $date);
 
-        return \DateTimeImmutable::createFromFormat('!m-d-y', $date, new \DateTimeZone('UTC')) ?: null;
+        return \DateTimeImmutable::createFromFormat('!d-m-y', $date, new \DateTimeZone('UTC')) ?: null;
     }
 
     /**


### PR DESCRIPTION
I found that when I was getting an anime list that all the dates were off, and so I found that the parser for Day-Month-Year dates was parsing them into Month-Day-Year dates instead.