### PR TITLE
add partial fix to incorrect airing status for Search

### DIFF
--- a/src/Parser/Search/AnimeSearchListItemParser.php
+++ b/src/Parser/Search/AnimeSearchListItemParser.php
@@ -145,6 +145,11 @@ class AnimeSearchListItemParser
      */
     public function isAiring(): bool
     {
+        // an entry with one episode can't be airing
+        // its either finished airing or hasn't aired yet
+        if (1 === $this->getEpisodes()) {
+            return false;
+        }
         // Start not yet known
         if (null === $this->getStartDate()) {
             return false;

--- a/test/JikanTest/Parser/Search/AnimeSearchEpisodeTest.php
+++ b/test/JikanTest/Parser/Search/AnimeSearchEpisodeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace JikanTest\Parser\Search;
+
+use Jikan\MyAnimeList\MalClient;
+use Jikan\Request\Search\AnimeSearchRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AnimeSearchEpisodeTest
+ */
+class AnimeSearchEpisodeTest extends TestCase
+{
+    /**
+     * @test
+     * @vcr AnimeSearchEpisodeTest.yaml
+     */
+    public function it_gets_one_episode_airing_false()
+    {
+        $jikan = new MalClient;
+        $this->search = $jikan->getAnimeSearch(new AnimeSearchRequest('Ijimekko Ookami to Nana-chan'));
+        $anime = $this->search->getResults()[0];
+        self::assertEquals('Ijimekko Ookami to Nana-chan', $anime->getTitle());
+        self::assertFalse($anime->isAiring());
+    }
+
+    /**
+     * @test
+     * @vcr AnimeSearchEpisodeTest.yaml
+     */
+    public function it_gets_multiple_episodes_airing_true()
+    {
+        $jikan = new MalClient;
+        $this->search = $jikan->getAnimeSearch(new AnimeSearchRequest('Bloody Bunny'));
+        $anime = $this->search->getResults()[0];
+        self::assertEquals('Bloody Bunny', $anime->getTitle());
+        self::assertTrue($anime->isAiring());
+    }
+}


### PR DESCRIPTION
If an anime has no `end_date`, the parser assumes that
it is airing. however, there are many shows on
MAL with incorrect information:
https://myanimelist.net/anime/26329/Ijimekko_Ookami_to_Nana-chan
https://myanimelist.net/anime/24793/Bloody_Bunny
which dont have end dates despite being finished airing
this does a quick check to see if an entry has only one
episode, and returns false since that cant be airing