### PR TITLE
fix the documentation block for AnimeSearchAiringTest

### DIFF
--- a/test/JikanTest/Parser/Search/AnimeSearchAiringTest.php
+++ b/test/JikanTest/Parser/Search/AnimeSearchAiringTest.php
@@ -7,7 +7,7 @@ use Jikan\Request\Search\AnimeSearchRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class AnimeSearchTest
+ * Class AnimeSearchAiringTest
  */
 class AnimeSearchAiringTest extends TestCase
 {


### PR DESCRIPTION
seems to have been a copy paste error, fix the name of the TestCase class in `AnimeSearchAiringTest.php`