### PR TITLE
Fix userupdates status parsing

### DIFF
--- a/src/Parser/User/Profile/LastUpdatesParser.php
+++ b/src/Parser/User/Profile/LastUpdatesParser.php
@@ -14,7 +14,7 @@ class LastUpdatesParser
     /**
      * @var Crawler
      */
-    private $crawler;
+    private Crawler $crawler;
 
     /**
      * LastUpdates constructor.
@@ -41,7 +41,7 @@ class LastUpdatesParser
     public function getLastAnimeUpdates(): array
     {
         $arr = $this->parseBaseListUpdates('anime');
-        $results = array();
+        $results = [];
         /**
          * @var $baseLastUpdate BaseLastUpdate
          */
@@ -58,7 +58,7 @@ class LastUpdatesParser
     public function getLastMangaUpdates(): array
     {
         $arr = $this->parseBaseListUpdates('manga');
-        $results = array();
+        $results = [];
         /**
          * @var $baseLastUpdate BaseLastUpdate
          */
@@ -88,7 +88,6 @@ class LastUpdatesParser
                 /** @var  $progressed int|null */
                 $progressed = null;
 
-                $status = "";
                 $progressedTotalSeparatorIndex = strpos($progressTypeValueUnparsed, '/');
                 if ($progressedTotalSeparatorIndex != false) {
                     $totalUnparsed = substr($progressTypeValueUnparsed, $progressedTotalSeparatorIndex + 1);
@@ -97,6 +96,7 @@ class LastUpdatesParser
                     $progressed = ctype_digit($progressedUnparsed) ? intval($progressedUnparsed) : null;
                     $status = trim(substr($progressTypeValueUnparsed, 0, $progressedTotalSeparatorIndex - 2));
                 } else {
+                    $progressTypeValueUnparsed = str_replace(" -", "", $progressTypeValueUnparsed);
                     $status = trim($progressTypeValueUnparsed);
                 }
                 return new BaseLastUpdate($url, $title, $imageUrl, $progressed, $total, $status, $score, $date);


### PR DESCRIPTION
List entries, with any status except Plan to Watch/Read, when list entry has zero progress (0 watched episodes/0 read chapters) and entry doesn't have total episodes/chapters, in most cases it means that entry is ongoing, MAL displays like `Status -` e.g. `Watching -` instead of `Watching` or `Watching -/?`.

This PR simply replaces ` -` with empty string which later will be trimmed in such type of list entries statuses. It doesn't affect entries with `On-Hold` status since they don't have space before dash, and no other status on MAL have dashes in it.

Example in my profile https://myanimelist.net/profile/N0D4N
![image](https://user-images.githubusercontent.com/50947930/114320898-dfbe9500-9b20-11eb-9e9a-a8f437f975c5.png)
Plan To Watch entries are displayed with just status.
Reading with non zero progress but unknown total chapters is displayed as `Reading 3/?`
Dropped with zero progress and known total chapters is displayed as `Dropped -/58`
Completed with zero progress and zero total chapters is displayed as `Completed -`