### PR TITLE
Update Goutte to version 4 removing the GuzzlePHP dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "fabpot/goutte": "^3.2",
+        "fabpot/goutte": "^4.0",
         "php": "^7.4",
         "ext-json": "*"
     },

--- a/src/MyAnimeList/MalClient.php
+++ b/src/MyAnimeList/MalClient.php
@@ -11,13 +11,13 @@
 
 namespace Jikan\MyAnimeList;
 
-use GuzzleHttp\Client as GuzzleClient;
 use Jikan\Exception\BadResponseException;
 use Jikan\Exception\ParserException;
 use Jikan\Goutte\GoutteWrapper;
 use Jikan\Model;
 use Jikan\Parser;
 use Jikan\Request;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Class MalClient
@@ -32,16 +32,13 @@ class MalClient
     /**
      * MalClient constructor.
      *
-     * @param GuzzleClient|null $guzzle
+     * @param HttpClientInterfac|null $httpClient
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(GuzzleClient $guzzle = null)
+    public function __construct(HttpClientInterface $httpClient = null)
     {
-        $this->ghoutte = new GoutteWrapper();
-        if ($guzzle !== null) {
-            $this->ghoutte->setClient($guzzle);
-        }
+        $this->ghoutte = new GoutteWrapper($httpClient);
     }
 
     /**

--- a/src/Parser/Forum/ForumTopicParser.php
+++ b/src/Parser/Forum/ForumTopicParser.php
@@ -7,7 +7,6 @@ use Jikan\Helper\JString;
 use Jikan\Helper\Parser;
 use Jikan\Model\Forum\ForumPost;
 use Symfony\Component\DomCrawler\Crawler;
-use function GuzzleHttp\Psr7\parse_query;
 
 /**
  * Class ForumPostParser
@@ -37,7 +36,7 @@ class ForumTopicParser
      */
     public function getTopicId(): int
     {
-        $query = parse_query(explode('?', $this->getUrl())[1]);
+        parse_str(explode('?', $this->getUrl())[1], $query);
 
         return (int)$query['topicid'];
     }


### PR DESCRIPTION
The PHPUnit tests seem to not work anymore so I didn't update them but I did an integration test on my own any it seems to work correctly. I'm just making this PR to share my change.

This is a breaking change I would say so you might want me to target it to the 3.0 branch.