### PR TITLE
Fix parser for user updates for status and total chapters/episodes 

### DIFF
--- a/src/Parser/User/Profile/LastUpdatesParser.php
+++ b/src/Parser/User/Profile/LastUpdatesParser.php
@@ -90,15 +90,16 @@ class LastUpdatesParser
 
                 $progressedTotalSeparatorIndex = strpos($progressTypeValueUnparsed, '/');
                 if ($progressedTotalSeparatorIndex != false) {
-                    $totalUnparsed = substr($progressTypeValueUnparsed, $progressedTotalSeparatorIndex + 1);
-                    $total = ctype_digit($totalUnparsed) ? intval($scoreUnparsed) : null;
-                    $progressedUnparsed = trim(substr($progressTypeValueUnparsed, $progressedTotalSeparatorIndex - 2, 2));
+                    $totalUnparsed = trim(substr($progressTypeValueUnparsed, $progressedTotalSeparatorIndex + 1));
+                    $total = ctype_digit($totalUnparsed) ? intval($totalUnparsed) : null;
+                    $lastSpace = strpos($progressTypeValueUnparsed, " ", -0);
+                    $progressedUnparsed = trim(substr($progressTypeValueUnparsed, $lastSpace, $progressedTotalSeparatorIndex - $lastSpace));
                     $progressed = ctype_digit($progressedUnparsed) ? intval($progressedUnparsed) : null;
-                    $status = trim(substr($progressTypeValueUnparsed, 0, $progressedTotalSeparatorIndex - 2));
-                } else {
-                    $progressTypeValueUnparsed = str_replace(" -", "", $progressTypeValueUnparsed);
-                    $status = trim($progressTypeValueUnparsed);
+                    $status = trim(substr($progressTypeValueUnparsed, 0, $progressedTotalSeparatorIndex - strlen($progressedUnparsed)));
+                    return new BaseLastUpdate($url, $title, $imageUrl, $progressed, $total, $status, $score, $date);
                 }
+                $progressTypeValueUnparsed = str_replace(" -", "", $progressTypeValueUnparsed);
+                $status = trim($progressTypeValueUnparsed);
                 return new BaseLastUpdate($url, $title, $imageUrl, $progressed, $total, $status, $score, $date);
             });
     }


### PR DESCRIPTION
Reported in https://discord.com/channels/460491088004907029/462991054619148288/859795976558477312
Fixes parsing for status by not assuming that max length of user watched episodes/read chapters is 2.
Fixes parsing for total chapters/episodes, current implementation parses it from score due mistype.