### PR TITLE
bugfix: renamed manga character container class

### DIFF
--- a/src/Parser/Manga/CharactersParser.php
+++ b/src/Parser/Manga/CharactersParser.php
@@ -35,7 +35,7 @@ class CharactersParser
     public function getCharacters(): array
     {
         return $this->crawler
-            ->filterXPath('//div[contains(@class, "anime-character-container")]/table')
+            ->filterXPath('//div[contains(@class, "manga-character-container")]/table')
             ->each(
                 function (Crawler $crawler) {
                     return CharacterListItem::fromParser(new CharacterListItemParser($crawler));


### PR DESCRIPTION
MAL changed the container class on the manga character page
from `anime-container-class` to `manga-container-class`

See source here; https://myanimelist.net/manga/1/_/characters

Seems all the [CharacterListItemParser](https://github.com/jikan-me/jikan/blob/master/src/Parser/Character/CharacterListItemParser.php) code is unaffected, since it didn't
depend on anime or manga class items on the page
