### PR TITLE
bugfix/userlist: add genre/demographic IDs to URL

### DIFF
--- a/src/Model/User/AnimeListItem.php
+++ b/src/Model/User/AnimeListItem.php
@@ -236,7 +236,7 @@ class AnimeListItem
             foreach ($item->genres as $genre) {
                 $instance->genres[] = new MalUrl(
                     $genre->name,
-                    Constants::BASE_URL . "/anime/genre/{$genre->name}"
+                    Constants::BASE_URL . "/anime/genre/{$genre->id}/{$genre->name}"
                 );
             }
         }
@@ -245,7 +245,7 @@ class AnimeListItem
             foreach ($item->demographics as $demographic) {
                 $instance->demographics[] = new MalUrl(
                     $demographic->name,
-                    Constants::BASE_URL . "/anime/genre/{$demographic->name}"
+                    Constants::BASE_URL . "/anime/genre/{$demographic->id}/{$demographic->name}"
                 );
             }
         }

--- a/src/Model/User/MangaListItem.php
+++ b/src/Model/User/MangaListItem.php
@@ -186,7 +186,7 @@ class MangaListItem
             foreach ($item->genres as $genre) {
                 $instance->genres[] = new MalUrl(
                     $genre->name,
-                    Constants::BASE_URL . "/manga/genre/{$genre->name}"
+                    Constants::BASE_URL . "/manga/genre/{$genre->id}/{$genre->name}"
                 );
             }
         }
@@ -195,7 +195,7 @@ class MangaListItem
             foreach ($item->demographics as $demographic) {
                 $instance->demographics[] = new MalUrl(
                     $demographic->name,
-                    Constants::BASE_URL . "/manga/genre/{$demographic->name}"
+                    Constants::BASE_URL . "/manga/genre/{$demographic->id}/{$demographic->name}"
                 );
             }
         }


### PR DESCRIPTION
On a request like https://api.jikan.moe/v3/user/QCTFW/animelist

Currently it looks like:

```
{
  "genres": [
        {
          "mal_id": 0,
          "type": "anime",
          "name": "Comedy",
          "url": "https://myanimelist.net/anime/genre/Comedy"
        },
        {
          "mal_id": 0,
          "type": "anime",
          "name": "Romance",
          "url": "https://myanimelist.net/anime/genre/Romance"
        },
        {
          "mal_id": 0,
          "type": "anime",
          "name": "Slice of Life",
          "url": "https://myanimelist.net/anime/genre/Slice of Life"
        }
      ],
      "demographics": [
        {
          "mal_id": 0,
          "type": "anime",
          "name": "Shounen",
          "url": "https://myanimelist.net/anime/genre/Shounen"
        }
      ]
}
```

Since the mal id isn't put into the MalUrl object, so it can't parse it out of the URL

Just added it as part of the URL, previous URLs weren't valid