### PR TITLE
Allow using PHP 8.0 with Jikan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "fabpot/goutte": "^4.0",
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
To be able to develop and test PHP 8.0 it needs to be allowed in the composer.json first