### PR TITLE
Fix #395: Move from parents() to ancestors() in goutte

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         }
     },
     "require": {
-        "fabpot/goutte": "4.0.1",
         "php": "^7.4|^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "fabpot/goutte": "^4.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.4.1",

--- a/src/Helper/MalUrlExtractor.php
+++ b/src/Helper/MalUrlExtractor.php
@@ -55,7 +55,7 @@ class MalUrlExtractor
         if (!$this->imageLinks) {
             $this->crawler->filterXPath('//a/img')->each(
                 function (Crawler $c) {
-                    $node = $c->parents()->first()->getNode(0);
+                    $node = $c->ancestors()->first()->getNode(0);
                     /**
                 *
                      *

--- a/src/Parser/Anime/AnimeParser.php
+++ b/src/Parser/Anime/AnimeParser.php
@@ -106,7 +106,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($title->text(), '', $title->parents()->text())
+            str_replace($title->text(), '', $title->ancestors()->text())
         );
     }
 
@@ -123,7 +123,7 @@ class AnimeParser implements ParserInterface
             return [];
         }
 
-        $titles = str_replace($title->text(), '', $title->parents()->text());
+        $titles = str_replace($title->text(), '', $title->ancestors()->text());
         $titles = explode(', ', $titles);
 
         foreach ($titles as &$title) {
@@ -146,7 +146,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($title->text(), '', $title->parents()->text())
+            str_replace($title->text(), '', $title->ancestors()->text())
         );
     }
 
@@ -163,7 +163,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($type->text(), '', $type->parents()->text())
+            str_replace($type->text(), '', $type->ancestors()->text())
         );
     }
 
@@ -184,7 +184,7 @@ class AnimeParser implements ParserInterface
         return
             (
                 trim(
-                    str_replace($episodes->text(), '', $episodes->parents()->text())
+                    str_replace($episodes->text(), '', $episodes->ancestors()->text())
                 ) === 'Unknown'
             )
                 ?
@@ -193,7 +193,7 @@ class AnimeParser implements ParserInterface
                 (int)str_replace(
                     $episodes->text(),
                     '',
-                    $episodes->parents()->text()
+                    $episodes->ancestors()->text()
                 );
     }
 
@@ -210,7 +210,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($status->text(), '', $status->parents()->text())
+            str_replace($status->text(), '', $status->ancestors()->text())
         );
     }
 
@@ -228,7 +228,7 @@ class AnimeParser implements ParserInterface
         }
 
         $premiered = JString::cleanse(
-            str_replace($premiered->text(), '', $premiered->parents()->text())
+            str_replace($premiered->text(), '', $premiered->ancestors()->text())
         );
 
         if ($premiered === '?') {
@@ -252,7 +252,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($broadcast->text(), '', $broadcast->parents()->text())
+            str_replace($broadcast->text(), '', $broadcast->ancestors()->text())
         );
     }
 
@@ -266,8 +266,8 @@ class AnimeParser implements ParserInterface
         $producer = $this->crawler
             ->filterXPath('//span[text()="Producers:"]');
 
-        if ($producer->count() && strpos($producer->parents()->text(), 'None found') === false) {
-            return $producer->parents()->first()->filterXPath('//a')->each(
+        if ($producer->count() && strpos($producer->ancestors()->text(), 'None found') === false) {
+            return $producer->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -287,8 +287,8 @@ class AnimeParser implements ParserInterface
         $licensor = $this->crawler
             ->filterXPath('//span[text()="Licensors:"]');
 
-        if ($licensor->count() && strpos($licensor->parents()->text(), 'None found') === false) {
-            return $licensor->parents()->first()->filterXPath('//a')->each(
+        if ($licensor->count() && strpos($licensor->ancestors()->text(), 'None found') === false) {
+            return $licensor->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -307,8 +307,8 @@ class AnimeParser implements ParserInterface
     {
         $studio = $this->crawler->filterXPath('//span[text()="Studios:"]');
 
-        if ($studio->count() && strpos($studio->parents()->text(), 'None found') === false) {
-            return $studio->parents()->first()->filterXPath('//a')->each(
+        if ($studio->count() && strpos($studio->ancestors()->text(), 'None found') === false) {
+            return $studio->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -332,7 +332,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($source->text(), '', $source->parents()->text())
+            str_replace($source->text(), '', $source->ancestors()->text())
         );
     }
 
@@ -346,8 +346,8 @@ class AnimeParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Genres:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -357,8 +357,8 @@ class AnimeParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Genre:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -378,8 +378,8 @@ class AnimeParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Explicit Genres:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -389,8 +389,8 @@ class AnimeParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Explicit Genre:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -411,7 +411,7 @@ class AnimeParser implements ParserInterface
             ->filterXPath('//span[text()="Demographic:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -422,7 +422,7 @@ class AnimeParser implements ParserInterface
             ->filterXPath('//span[text()="Demographics:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -443,7 +443,7 @@ class AnimeParser implements ParserInterface
             ->filterXPath('//span[text()="Theme:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -454,7 +454,7 @@ class AnimeParser implements ParserInterface
             ->filterXPath('//span[text()="Themes:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -481,7 +481,7 @@ class AnimeParser implements ParserInterface
             str_replace(
                 '.',
                 '',
-                str_replace($duration->text(), '', $duration->parents()->text())
+                str_replace($duration->text(), '', $duration->ancestors()->text())
             )
         );
     }
@@ -500,7 +500,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($rating->text(), '', $rating->parents()->text())
+            str_replace($rating->text(), '', $rating->ancestors()->text())
         );
     }
 
@@ -559,7 +559,7 @@ class AnimeParser implements ParserInterface
         }
 
         $ranked = JString::cleanse(
-            Parser::removeChildNodes($rank->parents())->text()
+            Parser::removeChildNodes($rank->ancestors())->text()
         );
 
         if ($ranked === 'N/A') {
@@ -587,7 +587,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace([$popularity->text(), '#'], '', $popularity->parents()->text())
+            str_replace([$popularity->text(), '#'], '', $popularity->ancestors()->text())
         );
     }
 
@@ -605,7 +605,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace([$member->text(), ','], '', $member->parents()->text())
+            str_replace([$member->text(), ','], '', $member->ancestors()->text())
         );
     }
 
@@ -623,7 +623,7 @@ class AnimeParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace([$favorite->text(), ','], '', $favorite->parents()->text())
+            str_replace([$favorite->text(), ','], '', $favorite->ancestors()->text())
         );
     }
 

--- a/src/Parser/Anime/AnimeStatsParser.php
+++ b/src/Parser/Anime/AnimeStatsParser.php
@@ -41,7 +41,7 @@ class AnimeStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Watching:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -69,7 +69,7 @@ class AnimeStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Completed:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -87,7 +87,7 @@ class AnimeStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'On-Hold:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -105,7 +105,7 @@ class AnimeStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Dropped:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -123,7 +123,7 @@ class AnimeStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Plan to Watch:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -141,7 +141,7 @@ class AnimeStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Total:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {

--- a/src/Parser/Anime/CharactersAndStaffParser.php
+++ b/src/Parser/Anime/CharactersAndStaffParser.php
@@ -66,7 +66,7 @@ class CharactersAndStaffParser implements ParserInterface
     {
         $node = $this->crawler
             ->filterXPath('//h2[text()="Staff"]')
-            ->parents()->nextAll()
+            ->ancestors()->nextAll()
             ->reduce(
                 function (Crawler $crawler) {
                     return (bool)$crawler->filterXPath(

--- a/src/Parser/Common/AnimeCardParser.php
+++ b/src/Parser/Common/AnimeCardParser.php
@@ -460,6 +460,6 @@ class AnimeCardParser implements ParserInterface
      */
     public function isContinuing(): bool
     {
-        return strpos($this->crawler->parents()->text(), '(Continuing)') !== false;
+        return strpos($this->crawler->ancestors()->text(), '(Continuing)') !== false;
     }
 }

--- a/src/Parser/Manga/MangaParser.php
+++ b/src/Parser/Manga/MangaParser.php
@@ -110,7 +110,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($title->text(), '', $title->parents()->text())
+            str_replace($title->text(), '', $title->ancestors()->text())
         );
     }
 
@@ -128,7 +128,7 @@ class MangaParser implements ParserInterface
             return [];
         }
 
-        $titles = str_replace($title->text(), '', $title->parents()->text());
+        $titles = str_replace($title->text(), '', $title->ancestors()->text());
         $titles = explode(', ', $titles);
 
         foreach ($titles as &$title) {
@@ -152,7 +152,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($title->text(), '', $title->parents()->text())
+            str_replace($title->text(), '', $title->ancestors()->text())
         );
     }
 
@@ -170,7 +170,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($type->text(), '', $type->parents()->text())
+            str_replace($type->text(), '', $type->ancestors()->text())
         );
     }
 
@@ -191,7 +191,7 @@ class MangaParser implements ParserInterface
         return
             (
                 trim(
-                    str_replace($chapters->text(), '', $chapters->parents()->text())
+                    str_replace($chapters->text(), '', $chapters->ancestors()->text())
                 ) === 'Unknown'
             )
                 ?
@@ -200,7 +200,7 @@ class MangaParser implements ParserInterface
                 (int)str_replace(
                     $chapters->text(),
                     '',
-                    $chapters->parents()->text()
+                    $chapters->ancestors()->text()
                 );
     }
 
@@ -221,7 +221,7 @@ class MangaParser implements ParserInterface
         return
             (
                 trim(
-                    str_replace($volumes->text(), '', $volumes->parents()->text())
+                    str_replace($volumes->text(), '', $volumes->ancestors()->text())
                 ) === 'Unknown'
             )
                 ?
@@ -230,7 +230,7 @@ class MangaParser implements ParserInterface
                 (int)str_replace(
                     $volumes->text(),
                     '',
-                    $volumes->parents()->text()
+                    $volumes->ancestors()->text()
                 );
     }
 
@@ -248,7 +248,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($status->text(), '', $status->parents()->text())
+            str_replace($status->text(), '', $status->ancestors()->text())
         );
     }
 
@@ -293,8 +293,8 @@ class MangaParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Genres:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -304,8 +304,8 @@ class MangaParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Genre:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -325,8 +325,8 @@ class MangaParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Explicit Genres:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -336,8 +336,8 @@ class MangaParser implements ParserInterface
         $genre = $this->crawler
             ->filterXPath('//span[text()="Explicit Genre:"]');
 
-        if ($genre->count() && strpos($genre->parents()->text(), 'No genres have been added yet') === false) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+        if ($genre->count() && strpos($genre->ancestors()->text(), 'No genres have been added yet') === false) {
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -358,7 +358,7 @@ class MangaParser implements ParserInterface
             ->filterXPath('//span[text()="Demographics:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -369,7 +369,7 @@ class MangaParser implements ParserInterface
             ->filterXPath('//span[text()="Demographic:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -390,7 +390,7 @@ class MangaParser implements ParserInterface
             ->filterXPath('//span[text()="Theme:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -401,7 +401,7 @@ class MangaParser implements ParserInterface
             ->filterXPath('//span[text()="Themes:"]');
 
         if ($genre->count()) {
-            return $genre->parents()->first()->filterXPath('//a')->each(
+            return $genre->ancestors()->first()->filterXPath('//a')->each(
                 function (Crawler $crawler) {
                     return (new MalUrlParser($crawler))->getModel();
                 }
@@ -463,7 +463,7 @@ class MangaParser implements ParserInterface
             return null;
         }
 
-        $rank = Parser::removeChildNodes($rank->parents());
+        $rank = Parser::removeChildNodes($rank->ancestors());
         $ranked = trim(
             str_replace(
                 '#',
@@ -490,7 +490,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace([$popularity->text(), '#'], '', $popularity->parents()->text())
+            str_replace([$popularity->text(), '#'], '', $popularity->ancestors()->text())
         );
     }
 
@@ -509,7 +509,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace([$member->text(), ','], '', $member->parents()->text())
+            str_replace([$member->text(), ','], '', $member->ancestors()->text())
         );
     }
 
@@ -528,7 +528,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace([$favorite->text(), ','], '', $favorite->parents()->text())
+            str_replace([$favorite->text(), ','], '', $favorite->ancestors()->text())
         );
     }
 
@@ -636,7 +636,7 @@ class MangaParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($aired->text(), '', $aired->parents()->text())
+            str_replace($aired->text(), '', $aired->ancestors()->text())
         );
     }
 }

--- a/src/Parser/Manga/MangaStatsParser.php
+++ b/src/Parser/Manga/MangaStatsParser.php
@@ -41,7 +41,7 @@ class MangaStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Reading:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -69,7 +69,7 @@ class MangaStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Completed:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -87,7 +87,7 @@ class MangaStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'On-Hold:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -105,7 +105,7 @@ class MangaStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Dropped:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -123,7 +123,7 @@ class MangaStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Plan to Read:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {
@@ -141,7 +141,7 @@ class MangaStatsParser implements ParserInterface
             return $this->sanitize(
                 $this->crawler
                     ->filterXPath('//div[@class="spaceit_pad"]/span[contains(text(), \'Total:\')]')
-                    ->parents()
+                    ->ancestors()
                     ->getNode(0)->textContent
             );
         } catch (\Exception $e) {

--- a/src/Parser/Person/PersonParser.php
+++ b/src/Parser/Person/PersonParser.php
@@ -97,7 +97,7 @@ class PersonParser implements ParserInterface
         }
 
         return JString::cleanse(
-            str_replace($node->text(), '', $node->parents()->text())
+            str_replace($node->text(), '', $node->ancestors()->text())
         );
     }
 
@@ -117,7 +117,7 @@ class PersonParser implements ParserInterface
         // MAL screwed up the HTML here
         preg_match(
             '~Family name:(.*?)(Alternate names|Birthday|Website|Member Favorites|More)~',
-            $node->parents()->text(),
+            $node->ancestors()->text(),
             $matches
         );
 
@@ -149,7 +149,7 @@ class PersonParser implements ParserInterface
 
         $names = explode(
             ',',
-            str_replace($node->text(), '', $node->parents()->text())
+            str_replace($node->text(), '', $node->ancestors()->text())
         );
 
         foreach ($names as &$name) {
@@ -202,7 +202,7 @@ class PersonParser implements ParserInterface
 
         return Parser::parseDateMDYReadable(
             JString::cleanse(
-                str_replace($node->text(), '', $node->parents()->text())
+                str_replace($node->text(), '', $node->ancestors()->text())
             )
         );
     }
@@ -222,7 +222,7 @@ class PersonParser implements ParserInterface
         }
 
         return (int)JString::cleanse(
-            str_replace([$node->text(), ','], '', $node->parents()->text())
+            str_replace([$node->text(), ','], '', $node->ancestors()->text())
         );
     }
 


### PR DESCRIPTION
This will effectively drop support for `symfony/dom-crawler:v4.4` and
is thus a breaking change. Sadly the folks of symfony didn't merge
the `ancestors()` function back to the symfony 4.4 libraries but since
this change unlocks the upgrade path to laravel 9 and symfony 6 I
would say this is acceptable