### PR TITLE
Switch to maintained parallel-linter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "brianium/paratest": "^6.4.1",
         "doctrine/collections": "^1.5",
         "friendsofphp/php-cs-fixer": "^3.8",
-        "jakub-onderka/php-parallel-lint": "^1.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "jikan-me/jikan-fixtures": "dev-master",
         "php-vcr/php-vcr": "^1.6",
         "php-vcr/phpunit-testlistener-vcr": "^3.1",

--- a/test/JikanTest/Parser/Search/MangaSearchTest.php
+++ b/test/JikanTest/Parser/Search/MangaSearchTest.php
@@ -38,7 +38,7 @@ class MangaSearchTest extends TestCase
      */
     public function it_gets_the_image_url()
     {
-        self::assertEquals("https://cdn.myanimelist.net/images/manga/3/196931.jpg?s=7da8d65371bc975c9ecda0d30a832984", $this->manga->getImages()->);
+        self::assertEquals("https://cdn.myanimelist.net/images/manga/3/196931.jpg?s=7da8d65371bc975c9ecda0d30a832984", $this->manga->getImages()->getJpg()->getImageUrl());
     }
 
     /**


### PR DESCRIPTION
[jakub-onderka/php-parallel-lint](https://github.com/JakubOnderka/PHP-Parallel-Lint) is not maintained anymore and suggests to use [php-parallel-lint/PHP-Parallel-Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint) instead. The upgrade is as simple as the following:

```
composer remove --dev jakub-onderka/php-parallel-lint
composer require --dev php-parallel-lint/php-parallel-lint
```

This is the second step to make [grumphp](https://github.com/phpro/grumphp) green.