### PR TITLE
Fix anime rating value

### DIFF
--- a/src/Parser/Anime/AnimeParser.php
+++ b/src/Parser/Anime/AnimeParser.php
@@ -499,9 +499,15 @@ class AnimeParser implements ParserInterface
             return null;
         }
 
-        return JString::cleanse(
+        $rating = JString::cleanse(
             str_replace($rating->text(), '', $rating->ancestors()->text())
         );
+
+        if ($rating === 'None') {
+            return null;
+        }
+
+        return $rating;
     }
 
     /**


### PR DESCRIPTION
MAL changed their structure and now they display missing ratings as None instead of not displaying rating information. This PR contains a change which maps "None" to `null`.

Fixes jikan-me/jikan-rest#229