### PR TITLE
Added github actions for stale issues and automations through comments

### DIFF
--- a/.github/workflows/archive.yaml
+++ b/.github/workflows/archive.yaml
@@ -21,5 +21,5 @@ jobs:
           If this is still being worked on, please respond and we will re-open this pull request.
         stale-issue-label: 'archived'
         stale-pr-label: 'archived'
-        exempt-issue-label: 'in progress'
+        exempt-issue-label: 'in progress','feature request','bug'
         exempt-pr-label: 'in progress'

--- a/.github/workflows/archive.yaml
+++ b/.github/workflows/archive.yaml
@@ -21,5 +21,5 @@ jobs:
           If this is still being worked on, please respond and we will re-open this pull request.
         stale-issue-label: 'archived'
         stale-pr-label: 'archived'
-        exempt-issue-label: 'in progress,feature request, bug'
+        exempt-issue-label: 'in progress,feature request,bug'
         exempt-pr-label: 'in progress'

--- a/.github/workflows/archive.yaml
+++ b/.github/workflows/archive.yaml
@@ -21,5 +21,5 @@ jobs:
           If this is still being worked on, please respond and we will re-open this pull request.
         stale-issue-label: 'archived'
         stale-pr-label: 'archived'
-        exempt-issue-label: 'in progress','feature request','bug'
+        exempt-issue-label: 'in progress,feature request, bug'
         exempt-pr-label: 'in progress'

--- a/.github/workflows/archive.yaml
+++ b/.github/workflows/archive.yaml
@@ -1,0 +1,25 @@
+name: Archive
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 60
+        days-before-close: 18
+        stale-issue-message: >
+          This issue will be closed and archived in 18 days, as there has been no activity in the last 60 days.
+          If this issue is still relevant or you would like to see it actioned, please respond and we will re-open this issue.
+        stale-pr-message: >
+          This pull request will be closed and archived in 18 days, as there has been no activity in the last 60 days.
+          If this is still being worked on, please respond and we will re-open this pull request.
+        stale-issue-label: 'archived'
+        stale-pr-label: 'archived'
+        exempt-issue-label: 'in progress'
+        exempt-pr-label: 'in progress'

--- a/.github/workflows/comment-run.yaml
+++ b/.github/workflows/comment-run.yaml
@@ -1,0 +1,17 @@
+name: "Comment run"
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  comment-run:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # 0 indicates all history
+        fetch-depth: 0
+    - uses: nwtgck/actions-comment-run@v1.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        allowed-associations: '["OWNER", "COLLABORATOR"]'


### PR DESCRIPTION
Added two actions:
- One for cleaning up stale issues
- One for doing complex jobs by writing javascript code. E.g. you want to debug a test, or want to develop a github action which deals with issues and for now you just want to test the code this way. One good use case would be is duplication detection for issues when people are submitting bug reports.

The issue archive action skips those issues which are labeled with "in progress".