### PR TITLE
Fix episodes parsing

### DIFF
--- a/src/Parser/Anime/EpisodesParser.php
+++ b/src/Parser/Anime/EpisodesParser.php
@@ -57,14 +57,13 @@ class EpisodesParser implements ParserInterface
     public function getLastPage(): int
     {
         $pages = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[2]/div[2]/div/a[contains(@class, "link")]');
+            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "link")]');
 
         if (!$pages->count()) {
             return 1;
         }
 
         $pages = $pages
-            ->nextAll()
             ->last();
 
         if (!$pages->count()) {


### PR DESCRIPTION
Pagination on MAL could include an unescaped `<` which causes the crawler to create an incorrect HTML DOM. This PR contains a change which handles both the correct and the incorrect DOM.

Original DOM from MAL:

```
<div class="pagination ac">
    <a class="link" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?">1 - 100
    </a><span class="skip"><</span>
    <a class="link" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?offset=100">101 - 200</a>
    <a class="link" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?offset=200">201 - 300</a>
    <a class="link current" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?offset=300">301 - 358</a>
</div>
```

Crawler DOM:

```
<div class="pagination ac">
    <a class="link" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?">1 - 100</a>
    <span class="skip">
        <a class="link" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?offset=100">101 - 200</a>
        <a class="link" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?offset=200">201 - 300</a>
        <a class="link current" href="https://myanimelist.net/anime/516/Keroro_Gunsou/episode?offset=300">301 - 358</a>
    </span>
</div>
```

Fixes #439