### PR TITLE
adds anime streaming links #407

### DIFF
--- a/src/Model/Anime/Anime.php
+++ b/src/Model/Anime/Anime.php
@@ -208,6 +208,11 @@ class Anime
     private $externalLinks = [];
 
     /**
+     * @var Url[]
+     */
+    private $streamingLinks = [];
+
+    /**
      * Create an instance from an AnimeParser parser
      *
      * @param AnimeParser $parser
@@ -253,6 +258,7 @@ class Anime
         $instance->members = $parser->getMembers();
         $instance->favorites = $parser->getFavorites();
         $instance->externalLinks = $parser->getExternalLinks();
+        $instance->streamingLinks = $parser->getStreamingLinks();
         $instance->related = $parser->getRelated();
         $instance->openingThemes = $parser->getOpeningThemes();
         $instance->endingThemes = $parser->getEndingThemes();
@@ -299,6 +305,14 @@ class Anime
     public function getExternalLinks(): array
     {
         return $this->externalLinks;
+    }
+
+    /**
+     * @return Url[]
+     */
+    public function getStreamingLinks(): array
+    {
+        return $this->streamingLinks;
     }
 
     /**

--- a/src/Parser/Anime/AnimeParser.php
+++ b/src/Parser/Anime/AnimeParser.php
@@ -666,6 +666,24 @@ class AnimeParser implements ParserInterface
 
     /**
      * @return array
+     */
+    public function getStreamingLinks(): array
+    {
+        $links = $this->crawler
+            ->filterXPath('//*[@id="content"]/table/tr/td[1]/div/div[contains(@class, "broadcast")]//div[contains(@class, "broadcast")]');
+
+        if (!$links->count()) {
+            return [];
+        }
+
+        return $links->filterXPath('//a')
+            ->each(function (Crawler  $c) {
+                return (new UrlParser($c))->getModel();
+            });
+    }
+
+    /**
+     * @return array
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */

--- a/test/JikanTest/Parser/Anime/AnimeParserTest.php
+++ b/test/JikanTest/Parser/Anime/AnimeParserTest.php
@@ -380,4 +380,13 @@ class AnimeParserTest extends TestCase
         $preview = $this->parser->getPreview();
         self::assertEquals('https://www.youtube.com/embed/bJVyIXeUznY?enablejsapi=1&wmode=opaque&autoplay=1', $preview);
     }
+
+    /**
+     * @test
+     */
+    public function it_gets_the_streaming_links()
+    {
+        $streamingLinks = $this->parser->getStreamingLinks();
+        self::assertEquals('https://www.funimation.com/shows/trigun', $streamingLinks[0]->getUrl());
+    }
 }


### PR DESCRIPTION
Feature Request: https://github.com/jikan-me/jikan/issues/407

Adds new `streamingLinks` property to Anime model.

This will be serialized as data in REST under a new `/anime/{id}/streaming` endpoint and as `streaming` under `/anime/{id}/full`