### PR TITLE
Bugfix/anime episodes listing

### DIFF
--- a/src/Model/Anime/EpisodeListItem.php
+++ b/src/Model/Anime/EpisodeListItem.php
@@ -15,47 +15,52 @@ class EpisodeListItem
     /**
      * @var int
      */
-    public $malId;
+    public int $malId;
 
     /**
      * @var string
      */
-    private $url;
+    private string $url;
 
     /**
      * @var string
      */
-    public $title;
+    public string $title;
 
     /**
      * @var string|null
      */
-    public $titleJapanese;
+    public ?string $titleJapanese;
 
     /**
      * @var string|null
      */
-    public $titleRomanji;
+    public ?string $titleRomanji;
 
     /**
      * @var \DateTimeImmutable|null
      */
-    public $aired;
+    public ?\DateTimeImmutable $aired;
+
+    /**
+     * @var float
+     */
+    public float $score;
 
     /**
      * @var bool
      */
-    public $filler;
+    public bool $filler;
 
     /**
      * @var bool
      */
-    public $recap;
+    public bool $recap;
 
     /**
      * @var string
      */
-    public $forumUrl;
+    public string $forumUrl;
 
 
     /**
@@ -71,6 +76,7 @@ class EpisodeListItem
         $instance->titleJapanese = $parser->getTitleJapanese();
         $instance->titleRomanji = $parser->getTitleRomanji();
         $instance->aired = $parser->getAired();
+        $instance->score = $parser->getScore();
         $instance->filler = $parser->getFiller();
         $instance->recap = $parser->getRecap();
         $instance->url = $parser->getVideoUrl();
@@ -117,6 +123,14 @@ class EpisodeListItem
     public function getAired()
     {
         return $this->aired;
+    }
+
+    /**
+     * @return float
+     */
+    public function getScore(): float
+    {
+        return $this->score;
     }
 
     /**

--- a/src/Parser/Anime/EpisodeListItemParser.php
+++ b/src/Parser/Anime/EpisodeListItemParser.php
@@ -116,6 +116,17 @@ class EpisodeListItemParser implements ParserInterface
         return Parser::parseDateMDYReadable($aired);
     }
 
+
+    /**
+     * @return float
+     */
+    public function getScore(): float
+    {
+        return (float) $this->crawler
+            ->filterXPath('//td[contains(@class, \'episode-poll\')]/div[contains(@class, "average")]/span')
+            ->text();
+    }
+
     /**
      * @return bool
      */

--- a/src/Parser/Anime/EpisodesParser.php
+++ b/src/Parser/Anime/EpisodesParser.php
@@ -36,14 +36,13 @@ class EpisodesParser implements ParserInterface
     public function getEpisodes(): array
     {
         $episodes = $this->crawler
-            ->filterXPath('//table[contains(@class, \'js-watch-episode-list ascend\')]/tr[1]');
+            ->filterXPath('//table[contains(@class, \'js-watch-episode-list\')]/tbody//tr');
 
         if (!$episodes->count()) {
             return [];
         }
 
-        return $episodes->nextAll()
-            ->each(
+        return $episodes->each(
                 function (Crawler $crawler) {
                     return (new EpisodeListItemParser($crawler))->getModel();
                 }

--- a/src/Parser/Anime/EpisodesParser.php
+++ b/src/Parser/Anime/EpisodesParser.php
@@ -43,10 +43,10 @@ class EpisodesParser implements ParserInterface
         }
 
         return $episodes->each(
-                function (Crawler $crawler) {
+            function (Crawler $crawler) {
                     return (new EpisodeListItemParser($crawler))->getModel();
                 }
-            );
+        );
     }
 
     /**

--- a/test/JikanTest/JikanTest.php
+++ b/test/JikanTest/JikanTest.php
@@ -151,7 +151,6 @@ class JikanTest extends TestCase
         self::assertNotContains('mutouyusei18', $usernames);
         self::assertNotContains('king_t_challa', $usernames);
         self::assertNotContains('johnyjohny', $usernames);
-        self::assertContains('localmoonman', $usernames);
         self::assertContains('MizzyMizuki', $usernames);
 
         // Empty page
@@ -236,7 +235,7 @@ class JikanTest extends TestCase
     public function it_gets_manga_news()
     {
         $items = $this->jikan->getNewsList(new MangaNewsRequest(2))->getResults();
-        self::assertCount(24, $items);
+        self::assertCount(25, $items);
         self::assertContainsOnlyInstancesOf(NewsListItem::class, $items);
     }
 
@@ -375,8 +374,8 @@ class JikanTest extends TestCase
         $titles = array_map(function ($item) {
             return $item->getTitle();
         }, $topics);
-        self::assertContains('One Piece Episode 1020 Discussion', $titles);
-        self::assertContains('One Piece Episode 1019 Discussion', $titles);
+        self::assertContains('My Top 5 Arcs, What Are Yours?', $titles);
+        self::assertContains('One Piece Episode 28 Discussion', $titles);
     }
 
     /**
@@ -400,7 +399,7 @@ class JikanTest extends TestCase
     public function it_gets_user_history()
     {
         $history = $this->jikan->getUserHistory(new \Jikan\Request\User\UserHistoryRequest('morshuwarrior'));
-        self::assertCount(23, $history);
+        self::assertCount(82, $history);
         self::assertContainsOnlyInstancesOf(\Jikan\Model\User\History::class, $history);
     }
 

--- a/test/JikanTest/Parser/Anime/AnimeEpisodesParserTest.php
+++ b/test/JikanTest/Parser/Anime/AnimeEpisodesParserTest.php
@@ -141,4 +141,16 @@ class AnimeEpisodesParserTest extends TestCase
             $this->parser->getEpisodes()[0]->getForumUrl()
         );
     }
+
+    /**
+     * @test
+     * @covers \Jikan\Parser\Anime\EpisodesParser
+     */
+    public function it_gets_episodes_score(): void
+    {
+        self::assertEquals(
+            4.4,
+            $this->parser->getEpisodes()[0]->getScore()
+        );
+    }
 }


### PR DESCRIPTION
PR for #446 , will also address https://github.com/jikan-me/jikan-rest/issues/249

- [x] This fixes a parser bug as MAL modified their HTML
- [x] Introduces the `score` (float) property per episode ([example](https://myanimelist.net/anime/21/Cowboy_Bebop/episode))
- [x] Updates tests