### PR TITLE
Add anime videos episodes

### DIFF
--- a/src/Model/Anime/AnimeVideosEpisodes.php
+++ b/src/Model/Anime/AnimeVideosEpisodes.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Jikan\Model\Anime;
+
+use Jikan\Model\Common\Collection\Pagination;
+use Jikan\Model\Common\Collection\Results;
+use Jikan\Parser;
+
+/**
+ * Class AnimeVideosEpisodes
+ *
+ * @package Jikan\Model\Anime\AnimeVideosEpisodes
+ */
+class AnimeVideosEpisodes extends Results implements Pagination
+{
+
+    /**
+     * @var bool
+     */
+    private $hasNextPage = false;
+
+    /**
+     * @var int
+     */
+    private $lastVisiblePage = 1;
+
+
+    /**
+     * @param Parser\Anime\VideosParser $parser
+     * @return static
+     */
+    public static function fromParser(Parser\Anime\VideosParser $parser): self
+    {
+        $instance = new self();
+
+        $instance->results = $parser->getEpisodes();
+        $instance->hasNextPage = $parser->getHasNextPage();
+        $instance->lastVisiblePage = $parser->getLastPage();
+
+        return $instance;
+    }
+
+    /**
+     * @return static
+     */
+    public static function mock() : self
+    {
+        return new self();
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasNextPage(): bool
+    {
+        return $this->hasNextPage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastVisiblePage(): int
+    {
+        return $this->lastVisiblePage;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+}

--- a/src/MyAnimeList/MalClient.php
+++ b/src/MyAnimeList/MalClient.php
@@ -114,6 +114,24 @@ class MalClient
     }
 
     /**
+     * @param Request\Anime\AnimeVideosEpisodesRequest $request
+     * @return Model\Anime\AnimeVideosEpisodes
+     * @throws BadResponseException
+     * @throws ParserException
+     */
+    public function getAnimeVideosEpisodes(Request\Anime\AnimeVideosEpisodesRequest $request): Model\Anime\AnimeVideosEpisodes
+    {
+        $crawler = $this->ghoutte->request('GET', $request->getPath());
+        try {
+            $parser = new Parser\Anime\VideosParser($crawler);
+
+            return $parser->getResultsModel();
+        } catch (\Exception $e) {
+            throw ParserException::fromRequest($request, $e);
+        }
+    }
+
+    /**
      * @param  Request\Manga\MangaRequest $request
      * @return Model\Manga\Manga
      * @throws BadResponseException

--- a/src/Parser/Anime/VideosParser.php
+++ b/src/Parser/Anime/VideosParser.php
@@ -3,6 +3,7 @@
 namespace Jikan\Parser\Anime;
 
 use Jikan\Model\Anime\AnimeVideos;
+use Jikan\Model\Anime\AnimeVideosEpisodes;
 use Jikan\Model\Anime\PromoListItem;
 use Jikan\Parser\ParserInterface;
 use Symfony\Component\DomCrawler\Crawler;
@@ -17,7 +18,7 @@ class VideosParser implements ParserInterface
     /**
      * @var Crawler
      */
-    private $crawler;
+    private Crawler $crawler;
 
     /**
      * EpisodesParser constructor.
@@ -73,6 +74,85 @@ class VideosParser implements ParserInterface
     }
 
     /**
+     * @return bool
+     */
+    public function getHasNextPage(): bool
+    {
+        $node = $this->crawler
+            ->filterXPath('//div[contains(@class, "video-block episode-video")]//div[contains(@class, "pagination")]/a[text()[contains(.,"More")]]');
+
+        if ($node->count()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastPage(): int
+    {
+        $node = $this->crawler
+            ->filterXPath('//div[contains(@class, "video-block episode-video")]//div[contains(@class, "pagination")]/a[text()[contains(.,"Last")]]');
+
+        // All pages except the last page returns "Last" button
+        if ($node->count()) {
+            parse_str(
+                parse_url($node->attr('href'), PHP_URL_QUERY),
+                $params
+            );
+
+            return (int) $params['p'];
+        }
+
+        // Fallback 1
+        // The second last page doesn't return "Last" and only returns "More" as an indicator
+        // for the next or last page
+        $node = $this->crawler
+            ->filterXPath('//div[contains(@class, "video-block episode-video")]//div[contains(@class, "pagination")]/a[text()[contains(.,"More")]]');
+
+        if ($node->count()) {
+            parse_str(
+                parse_url($node->attr('href'), PHP_URL_QUERY),
+                $params
+            );
+
+            return (int) $params['p'];
+        }
+
+        // Fallback 2
+        // The last page only indicates the last page through a span element
+        $node = $this->crawler
+            ->filterXPath('//div[contains(@class, "video-block episode-video")]//div[contains(@class, "pagination")]/*[position()=last()]');
+
+        // Fallback 3
+        // The user has exceeded the pagination
+        // MAL still generates pagination here for some reason
+        // So we'll check other properties to see whether the page has ended or not
+        // otherwise fallback 2 will keep returning the generated page
+        $hasReachedTheEnd = $this->crawler
+            ->filterXPath('//div[contains(@class, "video-block episode-video")]//p[text()[contains(.,"No episode video has been added to this title")]]');
+
+        if ($hasReachedTheEnd->count()) {
+            // there is no way for us to know
+            // what the last accessible page is
+            // e.g https://myanimelist.net/anime/21/One_Piece/video?p=300
+            return 1;
+        }
+
+
+        if ($node->count()) {
+            // this element is not clickable and is returned as text
+
+            return (int) $node->text();
+        }
+
+        // if anything breaks
+        return 1;
+    }
+
+    /**
      * Return the model
      *
      * @throws \InvalidArgumentException
@@ -80,5 +160,15 @@ class VideosParser implements ParserInterface
     public function getModel(): AnimeVideos
     {
         return AnimeVideos::fromParser($this);
+    }
+
+    /**
+     * Return the results based model
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function getResultsModel(): AnimeVideosEpisodes
+    {
+        return AnimeVideosEpisodes::fromParser($this);
     }
 }

--- a/src/Request/Anime/AnimeVideosEpisodesRequest.php
+++ b/src/Request/Anime/AnimeVideosEpisodesRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jikan\Request\Anime;
+
+use Jikan\Request\RequestInterface;
+
+/**
+ * Class AnimeVideosEpisodesRequest
+ *
+ * @package Jikan\Request
+ */
+class AnimeVideosEpisodesRequest implements RequestInterface
+{
+    /**
+     * @var int
+     */
+    private int $id;
+
+    /**
+     * @var int
+     */
+    private int $page;
+
+    /**
+     * AnimeVideosEpisodesRequest constructor.
+     *
+     * @param int $id
+     */
+    public function __construct(int $id, int $page)
+    {
+        $this->id = $id;
+        $this->page = $page;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return sprintf('https://myanimelist.net/anime/%d/_/video?p=%d', $this->id, $this->page);
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+}

--- a/src/Request/Anime/AnimeVideosRequest.php
+++ b/src/Request/Anime/AnimeVideosRequest.php
@@ -5,7 +5,7 @@ namespace Jikan\Request\Anime;
 use Jikan\Request\RequestInterface;
 
 /**
- * Class AnimeVideos
+ * Class AnimeVideosRequest
  *
  * @package Jikan\Request
  */
@@ -14,7 +14,7 @@ class AnimeVideosRequest implements RequestInterface
     /**
      * @var int
      */
-    private $id;
+    private int $id;
 
     /**
      * AnimeVideosRequest constructor.


### PR DESCRIPTION
A much-requested feature. Issue ref #445 

Currently, anime videos return anime episodes and promo videos.

However, anime videos allow pagination on MAL. And this page specifically returns video thumbnails from Crunchyroll.
With the way AnimeVideos works, it returns only the first listing of anime episodes, trailers, and even Music Videos (which is currently not parsed by Jikan - PR as of #453 ).

Any sort of results-based model with pagination requires a different implementation so what I've done here is created a completely new request instead which can be called on by the REST API as a sub endpoint.

----

#### Usage

```php
$jikan = new \Jikan\MyAnimeList\MalClient();

$data = $jikan->getAnimeVideosEpisodes(
    new \Jikan\Request\Anime\AnimeVideosEpisodesRequest(21, 4) // mal_id, page
);

var_dump($data->getResults(), $data->getLastVisiblePage(), $data->hasNextPage());
```

----

#### Notes on REST API implementation

We won't be able to fit in the updated code here: `GET /v4/anime/21/videos` as an associative array is returned for episode listing. We need the parser to return a results-based model in order to handle the pagination on the REST API as well.
So instead we'll implement this with all its pagination glory as a new REST API endpoint `GET /v4/anime/21/videos/episodes`