### PR TITLE
Anime Videos: Add music videos

### DIFF
--- a/src/Model/Anime/AnimeVideos.php
+++ b/src/Model/Anime/AnimeVideos.php
@@ -14,12 +14,17 @@ class AnimeVideos
     /**
      * @var PromoListItem[]
      */
-    private $promo;
+    private array $promo;
 
     /**
      * @var StreamEpisodeListItem[]
      */
-    private $episodes;
+    private array $episodes;
+
+    /**
+     * @var MusicVideoListItem[]
+     */
+    private array $musicVideos;
 
     /**
      * @param VideosParser $parser
@@ -32,6 +37,7 @@ class AnimeVideos
         $instance = new self();
         $instance->episodes = $parser->getEpisodes();
         $instance->promo = $parser->getPromos();
+        $instance->musicVideos = $parser->getMusic();
 
         return $instance;
     }
@@ -50,5 +56,13 @@ class AnimeVideos
     public function getEpisodes(): array
     {
         return $this->episodes;
+    }
+
+    /**
+     * @return MusicVideoListItem[]
+     */
+    public function getMusicVideos()
+    {
+        return $this->musicVideos;
     }
 }

--- a/src/Model/Anime/MusicVideoListItem.php
+++ b/src/Model/Anime/MusicVideoListItem.php
@@ -16,17 +16,17 @@ class MusicVideoListItem
     /**
      * @var string
      */
-    public string $title;
+    private string $title;
 
     /**
      * @var YoutubeMeta
      */
-    public YoutubeMeta $video;
+    private YoutubeMeta $video;
 
     /**
      * @var MusicMeta
      */
-    public MusicMeta $meta;
+    private MusicMeta $meta;
 
 
     /**

--- a/src/Model/Anime/MusicVideoListItem.php
+++ b/src/Model/Anime/MusicVideoListItem.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jikan\Model\Anime;
+
+use Jikan\Model\Common\MusicMeta;
+use Jikan\Model\Common\YoutubeMeta;
+use Jikan\Parser\Anime\MusicVideoListItemParser;
+
+/**
+ * Class MusicVideoListItem
+ *
+ * @package Jikan\Model\Anime
+ */
+class MusicVideoListItem
+{
+    /**
+     * @var string
+     */
+    public string $title;
+
+    /**
+     * @var YoutubeMeta
+     */
+    public YoutubeMeta $video;
+
+    /**
+     * @var MusicMeta
+     */
+    public MusicMeta $meta;
+
+
+    /**
+     * @param MusicVideoListItemParser $parser
+     * @return static
+     */
+    public static function fromParser(MusicVideoListItemParser $parser): self
+    {
+        $instance = new self();
+        $instance->title = $parser->getTitle();
+        $instance->video = YoutubeMeta::factory($parser->getVideoUrl());
+        $instance->meta = $parser->getMusic();
+
+        return $instance;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return YoutubeMeta
+     */
+    public function getVideo(): YoutubeMeta
+    {
+        return $this->video;
+    }
+
+    /**
+     * @return MusicMeta
+     */
+    public function getMusic(): MusicMeta
+    {
+        return $this->music;
+    }
+}

--- a/src/Model/Anime/PromoListItem.php
+++ b/src/Model/Anime/PromoListItem.php
@@ -15,12 +15,12 @@ class PromoListItem
     /**
      * @var string
      */
-    public string $title;
+    private string $title;
 
     /**
      * @var YoutubeMeta
      */
-    public YoutubeMeta $trailer;
+    private YoutubeMeta $trailer;
 
     /**
      * @param PromoListItemParser $parser

--- a/src/Model/Anime/PromoListItem.php
+++ b/src/Model/Anime/PromoListItem.php
@@ -15,12 +15,12 @@ class PromoListItem
     /**
      * @var string
      */
-    public $title;
+    public string $title;
 
     /**
      * @var YoutubeMeta
      */
-    public $trailer;
+    public YoutubeMeta $trailer;
 
     /**
      * @param PromoListItemParser $parser

--- a/src/Model/Common/MusicMeta.php
+++ b/src/Model/Common/MusicMeta.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jikan\Model\Common;
+
+/**
+ * Class MusicMeta
+ *
+ * @package Jikan\Model\Common
+ */
+class MusicMeta
+{
+
+    /**
+     * @var string|null
+     */
+    private ?string $title;
+
+
+    /**
+     * @var string|null
+     */
+    private ?string $author;
+
+    /**
+     * @param string|null $title
+     * @param string|null $author
+     */
+    public function __construct(?string $title, ?string $author)
+    {
+        $this->title = $title;
+        $this->author = $author;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return "$this->title by $this->author";
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAuthor(): ?string
+    {
+        return $this->author;
+    }
+}

--- a/src/Parser/Anime/EpisodesParser.php
+++ b/src/Parser/Anime/EpisodesParser.php
@@ -44,8 +44,8 @@ class EpisodesParser implements ParserInterface
 
         return $episodes->each(
             function (Crawler $crawler) {
-                    return (new EpisodeListItemParser($crawler))->getModel();
-                }
+                return (new EpisodeListItemParser($crawler))->getModel();
+            }
         );
     }
 

--- a/src/Parser/Anime/MusicVideoListItemParser.php
+++ b/src/Parser/Anime/MusicVideoListItemParser.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Jikan\Parser\Anime;
+
+use Jikan\Model\Anime\MusicVideoListItem;
+use Jikan\Model\Common\MusicMeta;
+use Jikan\Parser\ParserInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class MusicVideoListItemParser
+ *
+ * @package Jikan\Parser\Anime
+ */
+class MusicVideoListItemParser implements ParserInterface
+{
+    /**
+     * @var Crawler
+     */
+    private Crawler $crawler;
+
+    /**
+     * MusicVideoListItemParser constructor.
+     *
+     * @param Crawler $crawler
+     */
+    public function __construct(Crawler $crawler)
+    {
+        $this->crawler = $crawler;
+    }
+
+
+    /**
+     * @return MusicVideoListItem
+     */
+    public function getModel(): MusicVideoListItem
+    {
+        return MusicVideoListItem::fromParser($this);
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getTitle(): string
+    {
+        return $this->crawler->filterXPath('//a/div/span')->text();
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getVideoUrl(): string
+    {
+        return $this->crawler->filterXPath('//a')->attr('href');
+    }
+
+    /**
+     * @return MusicMeta
+     */
+    public function getMusic(): MusicMeta
+    {
+        $node = $this->crawler->filterXPath('//div/div');
+
+        if (!$node->count()) {
+            return new MusicMeta(null, null);
+        }
+
+        preg_match('~(.*) by (.*)~', $node->text(), $matches);
+
+        return new MusicMeta($matches[1], $matches[2]);
+    }
+}

--- a/src/Parser/Anime/VideosParser.php
+++ b/src/Parser/Anime/VideosParser.php
@@ -3,6 +3,7 @@
 namespace Jikan\Parser\Anime;
 
 use Jikan\Model\Anime\AnimeVideos;
+use Jikan\Model\Anime\MusicVideoListItem;
 use Jikan\Model\Anime\PromoListItem;
 use Jikan\Parser\ParserInterface;
 use Symfony\Component\DomCrawler\Crawler;
@@ -68,6 +69,27 @@ class VideosParser implements ParserInterface
             ->each(
                 function (Crawler $crawler) {
                     return (new PromoListItemParser($crawler))->getModel();
+                }
+            );
+    }
+
+
+    /**
+     * @return MusicVideoListItem[]
+     */
+    public function getMusic(): array
+    {
+        $node = $this->crawler
+            ->filterXPath('//div[contains(@class, "video-block music-video")]/section/div');
+
+        if (!$node->count()) {
+            return [];
+        }
+
+        return $node
+            ->each(
+                function (Crawler $crawler) {
+                    return (new MusicVideoListItemParser($crawler))->getModel();
                 }
             );
     }


### PR DESCRIPTION
Didn't see this on MAL before but music videos are now also available.
e.g https://myanimelist.net/anime/21/One_Piece/video?p=1


This PR adds that. 

Might have a very minor merge conflict with https://github.com/jikan-me/jikan/pull/452
I suggest reviewing and merging that first.


----


New Model and parser added for MusicVideo, `MusicVideoListItem` and `MusicVideoListItemParser` respectively. 
Has similar model and parsing as `PromoListItem` as they both list youtube videos but a small difference is that some music video list items return the song's name and author (some are blank which are returned as `null`)

![image](https://user-images.githubusercontent.com/9166451/177855527-e7d24550-f3ea-43ae-a084-849911b65a05.png)
