### PR TITLE
Added animeAiredString property to Anime model

### DIFF
--- a/src/Model/Anime/Anime.php
+++ b/src/Model/Anime/Anime.php
@@ -99,6 +99,11 @@ class Anime
     /**
      * @var string|null
      */
+    private ?string $animeAiredString;
+
+    /**
+     * @var string|null
+     */
     private ?string $duration;
 
     /**
@@ -244,6 +249,7 @@ class Anime
         $instance->status = $parser->getStatus();
         $instance->airing = $instance->status === 'Currently Airing';
         $instance->aired = $parser->getAired();
+        $instance->animeAiredString = $parser->getAnimeAiredString();
         $instance->premiered = $parser->getPremiered();
         $instance->broadcast = $parser->getBroadcast();
         $instance->producers = $parser->getProducers();
@@ -442,6 +448,14 @@ class Anime
     public function getAired(): DateRange
     {
         return $this->aired;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAnimeAiredString(): ?string
+    {
+        return $this->animeAiredString;
     }
 
     /**


### PR DESCRIPTION
Related to #486, following [comment](https://github.com/jikan-me/jikan/issues/486#issuecomment-1289529390).

> @irfan-dahir Related to this issue, there currently is no property in the Anime model which allows to get the raw airdate string. So I would suggest adding a property there, which can use the the getAnimeAiredString from the AnimeParser. If you're okay with that, I can make the PR.