### PR TITLE
Bugfix/club members pagination

### DIFF
--- a/src/Parser/Club/UserListParser.php
+++ b/src/Parser/Club/UserListParser.php
@@ -83,6 +83,7 @@ class UserListParser implements ParserInterface
             ->filterXPath('//*[@id="content"]/div');
 
         preg_match('~Pages \((.*)\)~', $node->text(), $pages);
-        return (int) $pages[1];
+
+        return isset($pages[1]) ? (int) $pages[1] : 1;
     }
 }


### PR DESCRIPTION
attempts to fix #472 
I think this is caused by a warning thrown due to a non existent array index when there's no pagination (just one page) on the club members listing page.