### PR TITLE
Editorial update

### DIFF
--- a/src/Model/News/NewsList.php
+++ b/src/Model/News/NewsList.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Jikan\Model\Recommendations;
+namespace Jikan\Model\News;
 
 use Jikan\Model\Common\Collection\Pagination;
 use Jikan\Model\Common\Collection\Results;
 use Jikan\Parser;
 
 /**
- * Class RecentNews
+ * Class NewsList
  */
-class RecentNews extends Results implements Pagination
+class NewsList extends Results implements Pagination
 {
     /**
      * @var bool
@@ -23,16 +23,16 @@ class RecentNews extends Results implements Pagination
 
 
     /**
-     * @param Parser\News\RecentNewsParser $parser
+     * @param Parser\News\NewsListParser $parser
      * @return static
      */
-    public static function fromParser(Parser\News\RecentNewsParser $parser): self
+    public static function fromParser(Parser\News\NewsListParser $parser): self
     {
         $instance = new self();
 
-        $instance->results = $parser->getRecentNews();
-        $instance->lastVisiblePage = $parser->getLastPage();
-        $instance->hasNextPage = $parser->hasNextPage();
+        $instance->results = $parser->getResults();
+        $instance->lastVisiblePage = $parser->getLastVisiblePage();
+        $instance->hasNextPage = $parser->getHasNextPage();
 
         return $instance;
     }

--- a/src/Model/News/NewsListItem.php
+++ b/src/Model/News/NewsListItem.php
@@ -2,71 +2,94 @@
 
 namespace Jikan\Model\News;
 
-use Jikan\Model\Common\Collection\Pagination;
-use Jikan\Model\Common\Collection\Results;
-use Jikan\Parser;
+use Jikan\Model\Resource\NewsImageResource\NewsImageResource;
+use Jikan\Model\Resource\WrapImageResource\WrapImageResource;
+use Jikan\Parser\News\NewsListItemParser;
+use Jikan\Parser\News\ResourceNewsListItemParser;
 
 /**
- * Class ResourceNewsList
+ * Class AnimeParser
  *
- * @package Jikan\Model\News\ResourceNewsList
+ * @package Jikan\Model
  */
-class ResourceNewsList extends Results implements Pagination
+class NewsListItem
 {
     /**
-     * @var bool
+     * @var int|null
      */
-    private $hasNextPage = false;
+    private int|null $malId;
+
+    /**
+     * @var string
+     */
+    private string $url;
+
+    /**
+     * @var string
+     */
+    private string $title;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private \DateTimeImmutable $date;
+
+    /**
+     * @var string
+     */
+    private string $authorUsername;
+
+    /**
+     * @var string
+     */
+    private string $authorUrl;
+
+    /**
+     * @var string
+     */
+    private string $forumUrl;
+
+    /**
+     * @var NewsImageResource
+     */
+    private NewsImageResource $images;
 
     /**
      * @var int
      */
-    private $lastVisiblePage = 1;
+    private int $comments;
 
     /**
-     * @param Parser\News\ResourceNewsListParser $parser
+     * @var string
+     */
+    private string $excerpt;
+
+    /**
+     * @var array
+     */
+    private array $tags;
+
+    /**
+     * @param NewsListItemParser $parser
      *
-     * @return ResourceNewsList
-     * @throws \Exception
-     * @throws \RuntimeException
+     * @return NewsListItem
      * @throws \InvalidArgumentException
      */
-    public static function fromParser(Parser\News\ResourceNewsListParser $parser): self
+    public static function fromParser(NewsListItemParser $parser): NewsListItem
     {
         $instance = new self();
-
-        $instance->results = $parser->getResults();
-        $instance->hasNextPage = $parser->getHasNextPage();
+        $instance->malId = $parser->getMalId();
+        $instance->url = $parser->getUrl();
+        $instance->title = $parser->getTitle();
+        $instance->date = $parser->getDate();
+        $instance->authorUsername = $parser->getAuthor()->getName();
+        $instance->authorUrl = $parser->getAuthor()->getUrl();
+        $instance->forumUrl = $parser->getDiscussionLink();
+        $instance->images = NewsImageResource::factory($parser->getImageUrl());
+        $instance->comments = $parser->getComments();
+        $instance->excerpt = $parser->getExcerpt();
 
         return $instance;
     }
 
-    public static function mock() : self
-    {
-        return new self();
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasNextPage(): bool
-    {
-        return $this->hasNextPage;
-    }
-
-    /**
-     * @return int
-     */
-    public function getLastVisiblePage(): int
-    {
-        return $this->lastVisiblePage;
-    }
-
-    /**
-     * @return array
-     */
-    public function getResults(): array
-    {
-        return $this->results;
-    }
 }

--- a/src/Model/News/RecentNews.php
+++ b/src/Model/News/RecentNews.php
@@ -1,17 +1,15 @@
 <?php
 
-namespace Jikan\Model\News;
+namespace Jikan\Model\Recommendations;
 
 use Jikan\Model\Common\Collection\Pagination;
 use Jikan\Model\Common\Collection\Results;
 use Jikan\Parser;
 
 /**
- * Class ResourceNewsList
- *
- * @package Jikan\Model\News\ResourceNewsList
+ * Class RecentNews
  */
-class ResourceNewsList extends Results implements Pagination
+class RecentNews extends Results implements Pagination
 {
     /**
      * @var bool
@@ -23,27 +21,36 @@ class ResourceNewsList extends Results implements Pagination
      */
     private $lastVisiblePage = 1;
 
+
     /**
-     * @param Parser\News\ResourceNewsListParser $parser
-     *
-     * @return ResourceNewsList
-     * @throws \Exception
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
+     * @param Parser\News\RecentNewsParser $parser
+     * @return static
      */
-    public static function fromParser(Parser\News\ResourceNewsListParser $parser): self
+    public static function fromParser(Parser\News\RecentNewsParser $parser): self
     {
         $instance = new self();
 
-        $instance->results = $parser->getResults();
-        $instance->hasNextPage = $parser->getHasNextPage();
+        $instance->results = $parser->getRecentNews();
+        $instance->lastVisiblePage = $parser->getLastPage();
+        $instance->hasNextPage = $parser->hasNextPage();
 
         return $instance;
     }
 
+    /**
+     * @return static
+     */
     public static function mock() : self
     {
         return new self();
+    }
+
+    /**
+     * @return array
+     */
+    public function getResults(): array
+    {
+        return $this->results;
     }
 
     /**
@@ -60,13 +67,5 @@ class ResourceNewsList extends Results implements Pagination
     public function getLastVisiblePage(): int
     {
         return $this->lastVisiblePage;
-    }
-
-    /**
-     * @return array
-     */
-    public function getResults(): array
-    {
-        return $this->results;
     }
 }

--- a/src/Model/News/ResourceNewsList.php
+++ b/src/Model/News/ResourceNewsList.php
@@ -7,11 +7,11 @@ use Jikan\Model\Common\Collection\Results;
 use Jikan\Parser;
 
 /**
- * Class NewsList
+ * Class ResourceNewsList
  *
- * @package Jikan\Model\News\NewsList
+ * @package Jikan\Model\News\ResourceNewsList
  */
-class NewsList extends Results implements Pagination
+class ResourceNewsList extends Results implements Pagination
 {
     /**
      * @var bool
@@ -24,14 +24,14 @@ class NewsList extends Results implements Pagination
     private $lastVisiblePage = 1;
 
     /**
-     * @param Parser\News\NewsListParser $parser
+     * @param Parser\News\ResourceNewsListParser $parser
      *
-     * @return NewsList
+     * @return ResourceNewsList
      * @throws \Exception
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
-    public static function fromParser(Parser\News\NewsListParser $parser): self
+    public static function fromParser(Parser\News\ResourceNewsListParser $parser): self
     {
         $instance = new self();
 

--- a/src/Model/News/ResourceNewsListItem.php
+++ b/src/Model/News/ResourceNewsListItem.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Jikan\Model\News;
+
+use Jikan\Model\Resource\WrapImageResource\WrapImageResource;
+use Jikan\Parser\News\ResourceNewsListItemParser;
+
+/**
+ * Class AnimeParser
+ *
+ * @package Jikan\Model
+ */
+class ResourceNewsListItem
+{
+    /**
+     * @var int|null
+     */
+    private $malId;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private $date;
+
+    /**
+     * @var string
+     */
+    private $authorUsername;
+
+    /**
+     * @var string
+     */
+    private $authorUrl;
+
+    /**
+     * @var string
+     */
+    private $forumUrl;
+
+    /**
+     * @var WrapImageResource
+     */
+    private $images;
+
+    /**
+     * @var int
+     */
+    private $comments;
+
+    /**
+     * @var string
+     */
+    private $excerpt;
+
+    /**
+     * @param ResourceNewsListItemParser $parser
+     *
+     * @return ResourceNewsListItem
+     * @throws \InvalidArgumentException
+     */
+    public static function fromParser(ResourceNewsListItemParser $parser): self
+    {
+        $instance = new self();
+        $instance->malId = $parser->getMalId();
+        $instance->url = $parser->getUrl();
+        $instance->title = $parser->getTitle();
+        $instance->date = $parser->getDate();
+        $instance->authorUsername = $parser->getAuthor()->getName();
+        $instance->authorUrl = $parser->getAuthor()->getUrl();
+        $instance->forumUrl = $parser->getDiscussionLink();
+        $instance->images = WrapImageResource::factory($parser->getImage());
+        $instance->comments = $parser->getComments();
+        $instance->excerpt = $parser->getIntro();
+
+        return $instance;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMalId(): ?int
+    {
+        return $this->malId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getDate(): \DateTimeImmutable
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthorUsername(): string
+    {
+        return $this->authorUsername;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthorUrl(): string
+    {
+        return $this->authorUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getForumUrl(): string
+    {
+        return $this->forumUrl;
+    }
+
+    /**
+     * @return WrapImageResource
+     */
+    public function getImages(): WrapImageResource
+    {
+        return $this->images;
+    }
+
+    /**
+     * @return int
+     */
+    public function getComments(): int
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExcerpt(): string
+    {
+        return $this->excerpt;
+    }
+}

--- a/src/Model/Resource/NewsImageResource/Jpg.php
+++ b/src/Model/Resource/NewsImageResource/Jpg.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jikan\Model\Resource\NewsImageResource;
+
+/**
+ * Class Jpg
+ * @package Jikan\Model\Resource\NewsImageResource
+ */
+class Jpg
+{
+    /**
+     * @var string|null
+     */
+    private ?string $imageUrl;
+
+    /**
+     * @var string|null
+     */
+    private ?string $smallImageUrl;
+
+    /**
+     * @var string|null
+     */
+    private ?string $largeImageUrl;
+
+
+    /**
+     * @param string|null $imageUrl
+     * @return self
+     */
+    public static function factory(?string $imageUrl) : self
+    {
+        $instance = new self;
+
+        $instance->imageUrl = $imageUrl;
+
+        if ($instance->imageUrl === null) {
+            return $instance;
+        }
+
+        $instance->smallImageUrl = str_replace('/s/', '/r/100x156/s/', $imageUrl);
+        $instance->largeImageUrl = str_replace('/s/', '/r/200x312/s/', $imageUrl);
+
+        return $instance;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getImageUrl(): ?string
+    {
+        return $this->imageUrl;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSmallImageUrl(): ?string
+    {
+        return $this->smallImageUrl;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLargeImageUrl(): ?string
+    {
+        return $this->largeImageUrl;
+    }
+
+}

--- a/src/Model/Resource/NewsImageResource/NewsImageResource.php
+++ b/src/Model/Resource/NewsImageResource/NewsImageResource.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jikan\Model\Resource\NewsImageResource;
+
+use Jikan\Model\Resource\NewsImageResource\Jpg;
+
+/**
+ * Class NewsImageResource
+ * @package Jikan\Model\Resource\NewsImageResource
+ */
+class NewsImageResource
+{
+    /**
+     * @var Jpg
+     */
+    private Jpg $jpg;
+
+
+    /**
+     * @param string|null $imageUrl
+     * @return NewsImageResource
+     */
+    public static function factory(?string $imageUrl) : NewsImageResource
+    {
+        $instance = new self;
+
+        $instance->jpg = Jpg::factory($imageUrl);
+
+        return $instance;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString() : string
+    {
+        return $this->getJpg()->getImageUrl();
+    }
+
+    /**
+     * @return Jpg
+     */
+    public function getJpg(): Jpg
+    {
+        return $this->jpg;
+    }
+
+}

--- a/src/MyAnimeList/MalClient.php
+++ b/src/MyAnimeList/MalClient.php
@@ -1369,11 +1369,17 @@ class MalClient
     }
 
 
-    public function getRecentNews(Request\News\RecentNewsRequest $request): Model\News\RecentNews
+    /**
+     * @param Request\News\RecentNewsRequest $request
+     * @return Model\News\NewsList
+     * @throws BadResponseException
+     * @throws ParserException
+     */
+    public function getRecentNews(Request\News\RecentNewsRequest $request): Model\News\NewsList
     {
         $crawler = $this->ghoutte->request('GET', $request->getPath());
         try {
-            $parser = new Parser\News\RecentNewsParser($crawler);
+            $parser = new Parser\News\NewsListParser($crawler);
 
             return $parser->getModel();
         } catch (\Exception $e) {

--- a/src/MyAnimeList/MalClient.php
+++ b/src/MyAnimeList/MalClient.php
@@ -440,15 +440,15 @@ class MalClient
     /**
      * @param Request\RequestInterface $request
      *
-     * @return Model\News\NewsList
+     * @return Model\News\ResourceNewsList
      * @throws BadResponseException
      * @throws ParserException
      */
-    public function getNewsList(Request\RequestInterface $request): Model\News\NewsList
+    public function getNewsList(Request\RequestInterface $request): Model\News\ResourceNewsList
     {
         $crawler = $this->ghoutte->request('GET', $request->getPath());
         try {
-            $parser = new Parser\News\NewsListParser($crawler);
+            $parser = new Parser\News\ResourceNewsListParser($crawler);
 
             return $parser->getModel();
         } catch (\Exception $e) {
@@ -1363,6 +1363,19 @@ class MalClient
             $parser = new Parser\User\ClubParser($crawler);
 
             return $parser->getClubs();
+        } catch (\Exception $e) {
+            throw ParserException::fromRequest($request, $e);
+        }
+    }
+
+
+    public function getRecentNews(Request\News\RecentNewsRequest $request): Model\News\RecentNews
+    {
+        $crawler = $this->ghoutte->request('GET', $request->getPath());
+        try {
+            $parser = new Parser\News\RecentNewsParser($crawler);
+
+            return $parser->getModel();
         } catch (\Exception $e) {
             throw ParserException::fromRequest($request, $e);
         }

--- a/src/Parser/News/NewsListItemParser.php
+++ b/src/Parser/News/NewsListItemParser.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Jikan\Parser\News;
+
+use Jikan\Helper\Constants;
+use Jikan\Helper\JString;
+use Jikan\Helper\Parser;
+use Jikan\Model\Common\MalUrl;
+use Jikan\Model\News\NewsListItem;
+use Jikan\Model\News\ResourceNewsListItem;
+use Jikan\Parser\Common\MalUrlParser;
+use Jikan\Parser\ParserInterface;
+use PHPUnit\Exception;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class NewsListItemParser
+ *
+ * @package Jikan\Parser
+ */
+class NewsListItemParser implements ParserInterface
+{
+    /**
+     * @var Crawler
+     */
+    private Crawler $crawler;
+
+    /**
+     * NewsListItemParser constructor.
+     *
+     * @param Crawler $crawler
+     */
+    public function __construct(Crawler $crawler)
+    {
+        $this->crawler = $crawler;
+    }
+
+
+    public function getModel(): NewsListItem
+    {
+        return NewsListItem::fromParser($this);
+    }
+
+
+    public function getTitle(): string
+    {
+        return $this->crawler->filterXPath('//div[contains(@class,"news-unit-right")]/p/a')->text();
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMalId() : ?int
+    {
+        preg_match('~([\d]+)$~', $this->getUrl(), $matches);
+
+        if (!empty($matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getUrl(): string
+    {
+        return Constants::BASE_URL.$this->crawler
+                ->filterXPath('//div[contains(@class,"news-unit-right")]/p/a')
+                ->attr('href');
+    }
+
+    /**
+     * @return string|null
+     * @throws \InvalidArgumentException
+     */
+    public function getImageUrl(): ?string
+    {
+        $image = $this->crawler->filterXPath('//*[contains(@class, "image-link")]/img');
+
+        if (!$image->count()) {
+            return null;
+        }
+
+        return Parser::parseImageQuality(
+            $image->attr('src')
+        );
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     * @throws \InvalidArgumentException
+     */
+    public function getDate(): ?\DateTimeImmutable
+    {
+        return Parser::parseDate(
+            explode(' by',
+                Parser::removeChildNodes(
+                    $this->crawler
+                        ->filterXPath('//div[contains(@class,"news-unit-right")]/div[contains(@class, "information")]/p')
+                )->text()
+            )[0]
+        );
+    }
+
+    /**
+     * @return MalUrl
+     * @throws \InvalidArgumentException
+     */
+    public function getAuthor(): MalUrl
+    {
+        return (new MalUrlParser(
+            $this->crawler
+                ->filterXPath('//div[contains(@class,"news-unit-right")]/div[contains(@class, "information")]/p/a[1]')
+        ))->getModel();
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getDiscussionLink(): string
+    {
+        return Constants::BASE_URL.$this->crawler
+                ->filterXPath('//div[contains(@class,"news-unit-right")]/div[contains(@class, "information")]/p/a[last()]')
+                ->attr('href');
+    }
+
+    /**
+     * @return int
+     * @throws \InvalidArgumentException
+     */
+    public function getComments() : int
+    {
+        $comments = $this->crawler
+            ->filterXPath('//div[contains(@class,"news-unit-right")]/div[contains(@class, "information")]/p/a[last()]')
+            ->text();
+
+        preg_match('~\((\d+) comments\)~', $comments, $comments);
+        return !empty($comments) ? $comments[1] : 0;
+    }
+
+    /**
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getExcerpt(): string
+    {
+        return JString::cleanse(
+            $this->crawler
+                ->filterXPath('//div[contains(@class,"news-unit-right")]/div[contains(@class, "text")]')
+            ->text()
+        );
+    }
+}

--- a/src/Parser/News/NewsListParser.php
+++ b/src/Parser/News/NewsListParser.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Jikan\Parser\News;
+
+use Jikan\Model\News\NewsList;
+use Jikan\Parser\ParserInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class NewsListParser
+ *
+ * @package Jikan\Parser
+ */
+class NewsListParser implements ParserInterface
+{
+    /**
+     * @var Crawler
+     */
+    private Crawler $crawler;
+
+    /**
+     * NewsListParser constructor.
+     *
+     * @param Crawler $crawler
+     */
+    public function __construct(Crawler $crawler)
+    {
+        $this->crawler = $crawler;
+    }
+
+
+    public function getModel(): NewsList
+    {
+        return NewsList::fromParser($this);
+    }
+
+
+    public function getResults(): array
+    {
+        return $this->crawler
+            ->filterXPath('//*[@id="content"]/div[1]/div/div[contains(@class, "news-list")]/div[contains(@class, "news-unit") and contains(@class, "rect")]')
+            ->each(
+                function (Crawler $crawler) {
+                    return (new NewsListItemParser($crawler))->getModel();
+                }
+            );
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasNextPage(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastVisiblePage(): int
+    {
+        return 1;
+    }
+}

--- a/src/Parser/News/ResourceNewsListItemParser.php
+++ b/src/Parser/News/ResourceNewsListItemParser.php
@@ -6,17 +6,17 @@ use Jikan\Helper\Constants;
 use Jikan\Helper\JString;
 use Jikan\Helper\Parser;
 use Jikan\Model\Common\MalUrl;
-use Jikan\Model\News\NewsListItem;
+use Jikan\Model\News\ResourceNewsListItem;
 use Jikan\Parser\Common\MalUrlParser;
 use Jikan\Parser\ParserInterface;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
- * Class NewsListParser
+ * Class ResourceNewsListParser
  *
  * @package Jikan\Parser
  */
-class NewsListItemParser implements ParserInterface
+class ResourceNewsListItemParser implements ParserInterface
 {
     /**
      * @var Crawler
@@ -34,13 +34,13 @@ class NewsListItemParser implements ParserInterface
     }
 
     /**
-     * @return NewsListItem
+     * @return ResourceNewsListItem
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
-    public function getModel(): NewsListItem
+    public function getModel(): ResourceNewsListItem
     {
-        return NewsListItem::fromParser($this);
+        return ResourceNewsListItem::fromParser($this);
     }
 
     /**

--- a/src/Parser/News/ResourceNewsListParser.php
+++ b/src/Parser/News/ResourceNewsListParser.php
@@ -2,18 +2,18 @@
 
 namespace Jikan\Parser\News;
 
-use Jikan\Model\News\NewsList;
-use Jikan\Model\News\NewsListItem;
+use Jikan\Model\News\ResourceNewsList;
+use Jikan\Model\News\ResourceNewsListItem;
 use Jikan\Model\Search\AnimeSearch;
 use Jikan\Parser\ParserInterface;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
- * Class NewsListParser
+ * Class ResourceNewsListParser
  *
  * @package Jikan\Parser
  */
-class NewsListParser implements ParserInterface
+class ResourceNewsListParser implements ParserInterface
 {
     /**
      * @var Crawler
@@ -31,18 +31,18 @@ class NewsListParser implements ParserInterface
     }
 
     /**
-     * @return NewsList
+     * @return ResourceNewsList
      * @throws \Exception
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
-    public function getModel(): NewsList
+    public function getModel(): ResourceNewsList
     {
-        return NewsList::fromParser($this);
+        return ResourceNewsList::fromParser($this);
     }
 
     /**
-     * @return NewsListItem[]
+     * @return ResourceNewsListItem[]
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
@@ -52,7 +52,7 @@ class NewsListParser implements ParserInterface
             ->filterXPath('//div[contains(@class,"js-scrollfix-bottom-rel")]/div[@class="clearfix"]')
             ->each(
                 function (Crawler $crawler) {
-                    return (new NewsListItemParser($crawler))->getModel();
+                    return (new ResourceNewsListItemParser($crawler))->getModel();
                 }
             );
     }

--- a/src/Request/News/RecentNewsRequest.php
+++ b/src/Request/News/RecentNewsRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Jikan\Request\News;
+
+use Jikan\Request\RequestInterface;
+
+/**
+ * Class RecentNewsRequest
+ *
+ * @package Jikan\Request
+ */
+class RecentNewsRequest implements RequestInterface
+{
+    /**
+     * @var int
+     */
+    private $page;
+
+    /**
+     * AnimeRequest constructor.
+     *
+     * @param int $page
+     */
+    public function __construct(int $page)
+    {
+        $this->page = $page;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return sprintf('https://myanimelist.net/news?p=%d', $this->page);
+    }
+
+    /**
+     * @return int
+     */
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+}

--- a/test/JikanTest/Parser/News/NewsListItemParserTest.php
+++ b/test/JikanTest/Parser/News/NewsListItemParserTest.php
@@ -2,7 +2,7 @@
 
 namespace JikanTest\Parser\News;
 
-use Jikan\Parser\News\NewsListItemParser;
+use Jikan\Parser\News\ResourceNewsListItemParser;
 use JikanTest\TestCase;
 
 /**
@@ -11,7 +11,7 @@ use JikanTest\TestCase;
 class NewsListItemParserTest extends TestCase
 {
     /**
-     * @var NewsListItemParser
+     * @var ResourceNewsListItemParser
      */
     private $parser;
 
@@ -21,7 +21,7 @@ class NewsListItemParserTest extends TestCase
 
         $client = new \Goutte\Client($this->httpClient);
         $crawler = $client->request('GET', 'https://myanimelist.net/manga/2/Berserk/news');
-        $this->parser = new NewsListItemParser(
+        $this->parser = new ResourceNewsListItemParser(
             $crawler->filterXPath('//div[contains(@class,"js-scrollfix-bottom-rel")]/div[@class="clearfix"]')->first()
         );
     }


### PR DESCRIPTION
- [ ] Implement #391 
- [ ] Implement #491 
- [ ] Image URL Enhancements #488 
- [x] Refactors previously used `NewsList*` as `ResourceNewsList*`
- [ ] Write tests


Work in progress.