### PR TITLE
Allow Symfony 7.0 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "symfony/browser-kit": "^6.4",
-        "symfony/css-selector": "^6.4",
-        "symfony/http-client": "^6.4"
+        "symfony/browser-kit": "^6.4|^7.0",
+        "symfony/css-selector": "^6.4|^7.0",
+        "symfony/http-client": "^6.4|^7.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.3",

--- a/test/unit/Helper/JStringTest.php
+++ b/test/unit/Helper/JStringTest.php
@@ -19,7 +19,7 @@ class JStringTest extends TestCase
         self::assertSame($expected, $given);
     }
 
-    public function stringFloatProvider(): array
+    public static function stringFloatProvider(): array
     {
         return [
             [JString::isStringFloat('3.123'), true],

--- a/test/unit/Parser/Common/MalUrlParserTest.php
+++ b/test/unit/Parser/Common/MalUrlParserTest.php
@@ -33,7 +33,7 @@ class MalUrlParserTest extends TestCase
     /**
      * @return array
      */
-    public function urlProvider(): array
+    public static function urlProvider(): array
     {
         return [
             ['https://myanimelist.net/anime/12345'],


### PR DESCRIPTION
Symfony 7.0 cannot be used because of held back packages. Since 7.0 doesn't seem to have significant changes to the version 7.0 packages we should be able to safely support both ^6.4 and ^7.0