### PR TITLE
Fixes #551

### DIFF
--- a/src/Model/Common/MalUrl.php
+++ b/src/Model/Common/MalUrl.php
@@ -14,12 +14,12 @@ class MalUrl
     /**
      * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * @var string
      */
-    private $url;
+    private string $url;
 
     /**
      * Genre constructor.

--- a/src/Parser/Anime/AnimeParser.php
+++ b/src/Parser/Anime/AnimeParser.php
@@ -724,11 +724,47 @@ class AnimeParser implements ParserInterface
     public function getRelated(): array
     {
         $related = [];
+
+        // MAL has divided relations up into tiles and table format
+        // We first parse whatever there's in the tiles
         $this->crawler
-            ->filterXPath('//table[contains(@class, "anime_detail_related_anime")]/tr')
+            ->filterXPath('//div[contains(@class, "related-entries")]/div[contains(@class, "entries-tile")]/div[contains(@class, "entry")]')
             ->each(
                 function (Crawler $c) use (&$related) {
-                    $links = $c->filterXPath('//td[2]/a');
+                    $relation = $c->filterXPath('//div[@class="content"]/div[@class="relation"]')->text();
+
+                    // strip entry type (if any)
+                    $relation = JString::cleanse(
+                        preg_replace("~\s\(.*\)~", '', $relation)
+                    );
+
+                    $links = $c->filterXPath('//div[@class="content"]/div[@class="title"]/a');
+
+                    // Check for empty links #justMALThings
+                    if ($links->count() === 1 // if it's the only link MAL has listed
+                        && empty($links->first()->text()) // and if its a bugged/empty link
+                    ) {
+                        $related[$relation] = [];
+                        return;
+                    }
+
+                    // Remove empty/bugged links #justMALThings
+                    foreach ($links as $node) {
+                        if (empty($node->textContent)) {
+                            $node->parentNode->removeChild($node);
+                        }
+                    }
+
+                    $related[$relation][] = (new MalUrlParser($links))->getModel();
+                }
+            );
+
+        // Then we'll parse the table
+        $this->crawler
+            ->filterXPath('//table[contains(@class, "entries-table")]/tr')
+            ->each(
+                function (Crawler $c) use (&$related) {
+                    $links = $c->filterXPath('//td[2]//a');
                     $relation = JString::cleanse(
                         str_replace(':', '', $c->filterXPath('//td[1]')->text())
                     );

--- a/src/Parser/Manga/MangaParser.php
+++ b/src/Parser/Manga/MangaParser.php
@@ -611,11 +611,47 @@ class MangaParser implements ParserInterface
     public function getMangaRelated(): array
     {
         $related = [];
+
+        // MAL has divided relations up into tiles and table format
+        // We first parse whatever there's in the tiles
         $this->crawler
-            ->filterXPath('//table[contains(@class, "anime_detail_related_anime")]/tr')
+            ->filterXPath('//div[contains(@class, "related-entries")]/div[contains(@class, "entries-tile")]/div[contains(@class, "entry")]')
             ->each(
                 function (Crawler $c) use (&$related) {
-                    $links = $c->filterXPath('//td[2]/a');
+                    $relation = $c->filterXPath('//div[@class="content"]/div[@class="relation"]')->text();
+
+                    // strip entry type (if any)
+                    $relation = JString::cleanse(
+                        preg_replace("~\s\(.*\)~", '', $relation)
+                    );
+
+                    $links = $c->filterXPath('//div[@class="content"]/div[@class="title"]/a');
+
+                    // Check for empty links #justMALThings
+                    if ($links->count() === 1 // if it's the only link MAL has listed
+                        && empty($links->first()->text()) // and if its a bugged/empty link
+                    ) {
+                        $related[$relation] = [];
+                        return;
+                    }
+
+                    // Remove empty/bugged links #justMALThings
+                    foreach ($links as $node) {
+                        if (empty($node->textContent)) {
+                            $node->parentNode->removeChild($node);
+                        }
+                    }
+
+                    $related[$relation][] = (new MalUrlParser($links))->getModel();
+                }
+            );
+
+        // Then we'll parse the table
+        $this->crawler
+            ->filterXPath('//table[contains(@class, "entries-table")]/tr')
+            ->each(
+                function (Crawler $c) use (&$related) {
+                    $links = $c->filterXPath('//td[2]//a');
                     $relation = JString::cleanse(
                         str_replace(':', '', $c->filterXPath('//td[1]')->text())
                     );


### PR DESCRIPTION
- MAL returns tiles and table
- Tiles can contain any type of relation
- Usually, there's 1 or 2 tiles seen but the parser should get more if there are any
- table parsing is the same, was just wrapped in another div
- structure is the same for both anime and manga entries