### PR TITLE
doc: remove outdated elixir wrapper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ A REST API service is available as well
 | TypeScript | [jikants](https://github.com/Julien-Broyard/jikants) by Julien Broyard<br>[jikan-client](https://github.com/javi11/jikan-client) by Javier Blanco |
 | PHP        | [jikan-php](https://github.com/janvernieuwe/jikan-jikanPHP) by Jan Vernieuwe |
 | .NET       | [Jikan.net](https://github.com/Ervie/jikan.net) by Ervie |
-| Elixir     | [JikanEx](https://github.com/seanbreckenridge/jikan_ex) by Sean Breckenridge |
 | Go         | [jikan-go](https://github.com/darenliang/jikan-go) by Daren Liang<br>[jikan2go](https://github.com/nokusukun/jikan2go) by nokusukun |
 | Ruby       | [Jikan.rb](https://github.com/Zerocchi/jikan.rb) by Zerocchi |
 | Dart       | [jikan-dart](https://github.com/charafau/jikan-dart) by Rafal Wachol |


### PR DESCRIPTION
Has been on v3 and was never updated to v4, should probably just be removed.

If it was not clear, am the maintainer of that repo and haven't updated it in forever
