### PR TITLE
Symfony 8 support

### DIFF
--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP and linter
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           tools: parallel-lint, phpunit, php-cs-fixer
       - name: Run code quality checks
         run: ./.github/workflows/utilities/lint-pr ${{ github.base_ref }}

--- a/.github/workflows/code-quality-push.yaml
+++ b/.github/workflows/code-quality-push.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP and linter
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           tools: parallel-lint, phpunit, php-cs-fixer
       - name: Run code quality checks
         run: ./.github/workflows/utilities/lint-push

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 4
       matrix:
         operatingSystem: [ubuntu-22.04, windows-latest]
-        phpVersion: ['8.3']
+        phpVersion: ['8.4']
       fail-fast: false
     runs-on: ${{ matrix.operatingSystem }}
     name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}

--- a/src/Parser/Anime/AnimeParser.php
+++ b/src/Parser/Anime/AnimeParser.php
@@ -702,7 +702,7 @@ class AnimeParser implements ParserInterface
     public function getStreamingLinks(): array
     {
         $links = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[1]/div/div[contains(@class, "broadcast")]//div[contains(@class, "broadcast")]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[1]/div/div[contains(@class, "broadcast")]//div[contains(@class, "broadcast")]');
 
         if (!$links->count()) {
             return [];
@@ -766,7 +766,7 @@ class AnimeParser implements ParserInterface
 
         // Then we'll parse the table
         $this->crawler
-            ->filterXPath('//table[contains(@class, "entries-table")]/tr')
+            ->filterXPath('//table[contains(@class, "entries-table")]/tbody/tr')
             ->each(
                 function (Crawler $c) use (&$related) {
                     $links = $c->filterXPath('//td[2]//a');
@@ -853,7 +853,7 @@ class AnimeParser implements ParserInterface
      */
     public function getEndingThemes(): array
     {
-        $node = $this->crawler->filterXPath('//div[@class="theme-songs js-theme-songs ending"]/table/tr');
+        $node = $this->crawler->filterXPath('//div[@class="theme-songs js-theme-songs ending"]/table/tbody/tr');
 
         if (preg_match('~No ending themes have been added to this title~', $node->text())) {
             return [];

--- a/src/Parser/Anime/AnimeParser.php
+++ b/src/Parser/Anime/AnimeParser.php
@@ -259,7 +259,7 @@ class AnimeParser implements ParserInterface
     public function getPremiered(): ?string
     {
         $premiered = $this->crawler
-            ->filterXPath('//span[text()="Premiered:"]');
+            ->filterXPath('//span[contains(normalize-space(.), "Premiered:")]');
 
         if (!$premiered->count()) {
             return null;
@@ -834,9 +834,9 @@ class AnimeParser implements ParserInterface
      */
     public function getOpeningThemes(): array
     {
-        $node = $this->crawler->filterXPath('//div[@class="theme-songs js-theme-songs opnening"]/table/tr');
+        $node = $this->crawler->filterXPath('//div[@class="theme-songs js-theme-songs opnening"]/table/tbody/tr/td');
 
-        if (preg_match('~No opening themes have been added to this title~', $node->text())) {
+        if (str_contains($node->text(), 'No opening themes have been added to this title')) {
             return [];
         }
 

--- a/src/Parser/Anime/AnimeRecentlyUpdatedByUsersParser.php
+++ b/src/Parser/Anime/AnimeRecentlyUpdatedByUsersParser.php
@@ -36,7 +36,7 @@ class AnimeRecentlyUpdatedByUsersParser
     {
         try {
             return $this->crawler
-                ->filterXPath('//table[@class="table-recently-updated"]/tr[1]')
+                ->filterXPath('//table[@class="table-recently-updated"]/tbody/tr[1]')
                 ->nextAll()
                 ->each(
                     function ($c) {

--- a/src/Parser/Anime/AnimeStatsParser.php
+++ b/src/Parser/Anime/AnimeStatsParser.php
@@ -162,7 +162,7 @@ class AnimeStatsParser implements ParserInterface
             return [];
         }
 
-        $table = $this->crawler->filterXPath('//h2[text()="Score Stats"]/following-sibling::table[1]/tr');
+        $table = $this->crawler->filterXPath('//h2[text()="Score Stats"]/following-sibling::table[1]/tbody/tr');
 
         $scores = [];
         $table

--- a/src/Parser/Anime/EpisodesParser.php
+++ b/src/Parser/Anime/EpisodesParser.php
@@ -56,7 +56,7 @@ class EpisodesParser implements ParserInterface
     public function getLastPage(): int
     {
         $pages = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "link")]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "link")]');
 
         if (!$pages->count()) {
             return 1;
@@ -80,7 +80,7 @@ class EpisodesParser implements ParserInterface
     public function getHasNextPage(): bool
     {
         $isBeyondLastPage = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div/div[2]/table/tbody/tr/td/div[2]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div/div[2]/table/tbody/tr/td/div[2]');
 
         if (
             $isBeyondLastPage->count()
@@ -90,14 +90,14 @@ class EpisodesParser implements ParserInterface
         }
 
         $pageLinks = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "link")]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "link")]');
 
         if (!$pageLinks->count()) {
             return false;
         }
 
         $isLastPage = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "current") and position() = last()]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div[2]/div[2]/div[2]/div//a[contains(@class, "current") and position() = last()]');
 
         if ($isLastPage->count()) {
             return false;

--- a/src/Parser/Anime/VideosParser.php
+++ b/src/Parser/Anime/VideosParser.php
@@ -38,7 +38,7 @@ class VideosParser implements ParserInterface
     public function getEpisodes(): array
     {
         $episodes = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[2]/div[contains(@class, "video-block episode-video")]//*[contains(@class, "video-list-outer")]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div[2]/div[2]/div[contains(@class, "video-block episode-video")]//*[contains(@class, "video-list-outer")]');
 
         if (!$episodes->count()) {
             return [];

--- a/src/Parser/Character/CharacterListItemParser.php
+++ b/src/Parser/Character/CharacterListItemParser.php
@@ -39,7 +39,7 @@ class CharacterListItemParser implements ParserInterface
      */
     public function getVoiceActors(): array
     {
-        return $this->crawler->filterXPath('//table[2]/tr')->each(
+        return $this->crawler->filterXPath('//table[2]/tbody/tr')->each(
             function (Crawler $c) {
                 return new VoiceActorParser($c)->getModel();
             }

--- a/src/Parser/Character/CharacterParser.php
+++ b/src/Parser/Character/CharacterParser.php
@@ -112,7 +112,9 @@ class CharacterParser implements ParserInterface
      */
     public function getAbout(): ?string
     {
-        $crawler = $this->crawler->filterXPath('//*[@id="content"]/table/tr/td[2]');
+
+        $crawler = $this->crawler->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]');
+
         $aboutHtml = $crawler->html();
 
         $aboutHtml = str_replace(['<br>'], '\n', $aboutHtml);
@@ -135,7 +137,7 @@ class CharacterParser implements ParserInterface
      */
     public function getMemberFavorites(): int
     {
-        $crawler = $this->crawler->filterXPath('//*[@id="content"]/table/tr/td[1]');
+        $crawler = $this->crawler->filterXPath('//*[@id="content"]/table/tbody/tr/td[1]');
         $crawler = Parser::removeChildNodes($crawler);
 
         return (int) preg_replace('/\D/', '', $crawler->text());
@@ -157,7 +159,7 @@ class CharacterParser implements ParserInterface
     public function getAnimeography(): array
     {
         return $this->crawler
-            ->filterXPath('//div[contains(text(), \'Animeography\')]/../table[1]/tr')
+            ->filterXPath('//div[contains(text(), \'Animeography\')]/../table[1]/tbody/tr')
             ->each(
                 function (Crawler $c) {
                     return new AnimeographyParser($c)->getModel();
@@ -172,7 +174,7 @@ class CharacterParser implements ParserInterface
     public function getMangaography(): array
     {
         return $this->crawler
-            ->filterXPath('//div[contains(text(), \'Mangaography\')]/../table[2]/tr')
+            ->filterXPath('//div[contains(text(), \'Mangaography\')]/../table[2]/tbody/tr')
             ->each(
                 function (Crawler $c) {
                     return new MangaographyParser($c)->getModel();
@@ -188,7 +190,7 @@ class CharacterParser implements ParserInterface
     public function getVoiceActors(): array
     {
         return $this->crawler
-            ->filterXPath('//div[contains(text(), \'Voice Actors\')]/../table/tr')
+            ->filterXPath('//div[contains(text(), \'Voice Actors\')]/../table/tbody/tr')
             ->each(
                 function (Crawler $c) {
                     return new VoiceActorParser($c)->getModel();

--- a/src/Parser/Club/ClubParser.php
+++ b/src/Parser/Club/ClubParser.php
@@ -65,7 +65,7 @@ class ClubParser implements ParserInterface
     {
         return Parser::parseImageQuality(
             $this->crawler
-                ->filterXPath('//div[@id="content"]/table/tr/td[2]/div/div[1]/img')
+                ->filterXPath('//div[@id="content"]/table/tbody/tr/td[2]/div/div[1]/img')
                 ->attr('data-src')
         );
     }
@@ -85,7 +85,7 @@ class ClubParser implements ParserInterface
     {
         return (int) Parser::removeChildNodes(
             $this->crawler
-                ->filterXPath('//div[@id="content"]/table/tr/td[2]/div/div[4]')
+                ->filterXPath('//div[@id="content"]/table/tbody/tr/td[2]/div/div[4]')
         )->text();
     }
 
@@ -96,7 +96,7 @@ class ClubParser implements ParserInterface
     {
         return (int) Parser::removeChildNodes(
             $this->crawler
-                ->filterXPath('//div[@id="content"]/table/tr/td[2]/div/div[5]')
+                ->filterXPath('//div[@id="content"]/table/tbody/tr/td[2]/div/div[5]')
         )->text();
     }
 
@@ -108,7 +108,7 @@ class ClubParser implements ParserInterface
         $category = JString::cleanse(
             Parser::removeChildNodes(
                 $this->crawler
-                    ->filterXPath('//div[@id="content"]/table/tr/td[2]/div/div[6]')
+                    ->filterXPath('//div[@id="content"]/table/tbody/tr/td[2]/div/div[6]')
             )->text()
         );
 
@@ -122,7 +122,7 @@ class ClubParser implements ParserInterface
     public function getCreated(): \DateTimeImmutable
     {
         $node = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[2]/div/div[contains(., "Created")]');
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[2]/div/div[contains(., "Created")]');
 
         $date = JString::cleanse(
             Parser::removeChildNodes($node)
@@ -139,7 +139,7 @@ class ClubParser implements ParserInterface
     {
         $typeNode = JString::cleanse(
             $this->crawler
-                ->filterXPath('//div[@id="content"]/table/tr/td[2]/div')
+                ->filterXPath('//div[@id="content"]/table/tbody/tr/td[2]/div')
                 ->text()
         );
 

--- a/src/Parser/Club/UserListParser.php
+++ b/src/Parser/Club/UserListParser.php
@@ -43,7 +43,7 @@ class UserListParser implements ParserInterface
     public function getResults(): array
     {
         return $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td')
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td')
             ->each(
                 function (Crawler $crawler) {
                     return new UserProfileParser($crawler)->getModel();

--- a/src/Parser/Common/Recommendation.php
+++ b/src/Parser/Common/Recommendation.php
@@ -16,10 +16,7 @@ use Symfony\Component\DomCrawler\Crawler;
  */
 class Recommendation implements ParserInterface
 {
-    /**
-     * @var Crawler
-     */
-    private $crawler;
+    private \Symfony\Component\DomCrawler\Crawler $crawler;
 
     /**
      * Recommendation constructor.
@@ -38,7 +35,7 @@ class Recommendation implements ParserInterface
     public function getUrl(): string
     {
         return $this->crawler
-            ->filterXPath('//table/tr/td[2]/div[2]/a[1]')->attr('href');
+            ->filterXPath('//table/tbody/tr/td[2]/div[2]/a[1]')->attr('href');
     }
 
     /**
@@ -49,7 +46,7 @@ class Recommendation implements ParserInterface
     {
         return Parser::parseImageQuality(
             $this->crawler
-                ->filterXPath('//table/tr/td[1]/div[1]/a/img')->attr('data-src')
+                ->filterXPath('//table/tbody/tr/td[1]/div[1]/a/img')->attr('data-src')
         );
     }
 
@@ -60,7 +57,7 @@ class Recommendation implements ParserInterface
     public function getRecommendationurl(): string
     {
         return Constants::BASE_URL . $this->crawler
-            ->filterXPath('//table/tr/td[2]/div[2]/span/a')->attr('href');
+            ->filterXPath('//table/tbody/tr/td[2]/div[2]/span/a')->attr('href');
     }
 
     /**
@@ -70,7 +67,7 @@ class Recommendation implements ParserInterface
     public function getTitle(): string
     {
         return $this->crawler
-            ->filterXPath('//table/tr/td[2]/div[2]/a[1]')->text();
+            ->filterXPath('//table/tbody/tr/td[2]/div[2]/a[1]')->text();
     }
 
     /**
@@ -80,7 +77,7 @@ class Recommendation implements ParserInterface
     public function getRecommendationCount(): int
     {
         $node = $this->crawler
-            ->filterXPath('//table/tr/td[2]/div[4]/a[1]/strong');
+            ->filterXPath('//table/tbody/tr/td[2]/div[4]/a[1]/strong');
 
         if (!$node->count()) {
             return 1;

--- a/src/Parser/Manga/MangaParser.php
+++ b/src/Parser/Manga/MangaParser.php
@@ -21,10 +21,7 @@ use Symfony\Component\DomCrawler\Crawler;
  */
 class MangaParser implements ParserInterface
 {
-    /**
-     * @var Crawler
-     */
-    private $crawler;
+    private \Symfony\Component\DomCrawler\Crawler $crawler;
 
     /**
      * MangaParser constructor.
@@ -125,7 +122,7 @@ class MangaParser implements ParserInterface
     public function getMangaTitleEnglish(): ?string
     {
         $title = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="English:"]');
         if (!$title->count()) {
             return null;
@@ -143,7 +140,7 @@ class MangaParser implements ParserInterface
     public function getMangaTitleSynonyms(): array
     {
         $title = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Synonyms:"]');
 
         if (!$title->count()) {
@@ -167,7 +164,7 @@ class MangaParser implements ParserInterface
     public function getMangaTitleJapanese(): ?string
     {
         $title = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Japanese:"]');
         if (!$title->count()) {
             return null;
@@ -210,7 +207,7 @@ class MangaParser implements ParserInterface
     public function getMangaType(): ?string
     {
         $type = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Type:"]');
         if (!$type->count()) {
             return null;
@@ -227,7 +224,7 @@ class MangaParser implements ParserInterface
     public function getMangaChapters(): ?int
     {
         $chapters = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Chapters:"]');
 
         if (!$chapters->count()) {
@@ -255,7 +252,7 @@ class MangaParser implements ParserInterface
     public function getMangaVolumes(): ?int
     {
         $volumes = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Volumes:"]');
 
         if (!$volumes->count()) {
@@ -283,7 +280,7 @@ class MangaParser implements ParserInterface
     public function getMangaStatus(): ?string
     {
         $status = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Status:"]');
         if (!$status->count()) {
             return null;
@@ -510,7 +507,7 @@ class MangaParser implements ParserInterface
     public function getMangaRank(): ?int
     {
         $rank = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Ranked:"]');
 
         if (!$rank->count()) {
@@ -536,7 +533,7 @@ class MangaParser implements ParserInterface
     public function getMangaPopularity(): ?int
     {
         $popularity = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Popularity:"]');
 
         if (!$popularity->count()) {
@@ -555,7 +552,7 @@ class MangaParser implements ParserInterface
     public function getMangaMembers(): ?int
     {
         $member = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Members:"]');
 
         if (!$member->count()) {
@@ -574,7 +571,7 @@ class MangaParser implements ParserInterface
     public function getMangaFavorites(): ?int
     {
         $favorite = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Favorites:"]');
 
         if (!$favorite->count()) {
@@ -702,7 +699,7 @@ class MangaParser implements ParserInterface
             return null;
         }
         $background = $background->text();
-        if (preg_match('~No background information has been added to this title~', $background)) {
+        if (str_contains($background, 'No background information has been added to this title')) {
             return null;
         }
 
@@ -725,7 +722,7 @@ class MangaParser implements ParserInterface
     public function getMangaPublishedString(): ?string
     {
         $aired = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filterXPath('//span[text()="Published:"]');
 
         if (!$aired->count()) {

--- a/src/Parser/Manga/MangaRecentlyUpdatedByUsersParser.php
+++ b/src/Parser/Manga/MangaRecentlyUpdatedByUsersParser.php
@@ -37,7 +37,7 @@ class MangaRecentlyUpdatedByUsersParser
     {
         try {
             return $this->crawler
-                ->filterXPath('//table[@class="table-recently-updated"]/tr[1]')
+                ->filterXPath('//table[@class="table-recently-updated"]/tbody/tr[1]')
                 ->nextAll()
                 ->each(
                     function ($c) {

--- a/src/Parser/Manga/MangaReviewScoresParser.php
+++ b/src/Parser/Manga/MangaReviewScoresParser.php
@@ -43,14 +43,14 @@ class MangaReviewScoresParser implements ParserInterface
      */
     public function getOverallScore(): int
     {
-        return (int) $this->crawler->filterXPath('//table/tr[1]/td[2]/strong')->text();
+        return (int) $this->crawler->filterXPath('//table/tbody/tr[1]/td[2]/strong')->text();
     }
     /**
      * @return int
      */
     public function getStoryScore(): int
     {
-        return (int) $this->crawler->filterXPath('//table/tr[2]/td[2]')->text();
+        return (int) $this->crawler->filterXPath('//table/tbody/tr[2]/td[2]')->text();
     }
 
     /**
@@ -58,7 +58,7 @@ class MangaReviewScoresParser implements ParserInterface
      */
     public function getArtScore(): int
     {
-        return (int) $this->crawler->filterXPath('//table/tr[3]/td[2]')->text();
+        return (int) $this->crawler->filterXPath('//table/tbody/tr[3]/td[2]')->text();
     }
 
     /**
@@ -66,7 +66,7 @@ class MangaReviewScoresParser implements ParserInterface
      */
     public function getCharacterScore(): int
     {
-        return (int) $this->crawler->filterXPath('//table/tr[4]/td[2]')->text();
+        return (int) $this->crawler->filterXPath('//table/tbody/tr[4]/td[2]')->text();
     }
 
     /**
@@ -74,6 +74,6 @@ class MangaReviewScoresParser implements ParserInterface
      */
     public function getEnjoymentScore(): int
     {
-        return (int) $this->crawler->filterXPath('//table/tr[5]/td[2]')->text();
+        return (int) $this->crawler->filterXPath('//table/tbody/tr[5]/td[2]')->text();
     }
 }

--- a/src/Parser/Manga/MangaStatsParser.php
+++ b/src/Parser/Manga/MangaStatsParser.php
@@ -162,7 +162,7 @@ class MangaStatsParser implements ParserInterface
             return [];
         }
 
-        $table = $this->crawler->filterXPath('//h2[text()="Score Stats"]/following-sibling::table[1]/tr');
+        $table = $this->crawler->filterXPath('//h2[text()="Score Stats"]/following-sibling::table[1]/tbody/tr');
 
         $scores = [];
         $table->each(

--- a/src/Parser/News/NewsParser.php
+++ b/src/Parser/News/NewsParser.php
@@ -174,7 +174,7 @@ class NewsParser implements ParserInterface
     {
         $related = [];
         $this->crawler
-            ->filterXPath('//table[contains(@class, "news-related-database")]/tr')
+            ->filterXPath('//table[contains(@class, "news-related-database")]/tbody/tr')
             ->each(
                 function (Crawler $c) use (&$related) {
                     $links = $c->filterXPath('//td[2]/a');

--- a/src/Parser/News/NewsTagsParser.php
+++ b/src/Parser/News/NewsTagsParser.php
@@ -51,7 +51,7 @@ class NewsTagsParser implements ParserInterface
                         ->text();
 
                     return $crawler
-                        ->filterXPath('//table/tr')
+                        ->filterXPath('//table/tbody/tr')
                         ->each(function (Crawler $crawler) use ($type) {
                             return new TagMeta(
                                 $crawler->filterXPath('//td[contains(@class, "tag-name")]/span/a')->text(),

--- a/src/Parser/News/ResourceNewsListParser.php
+++ b/src/Parser/News/ResourceNewsListParser.php
@@ -62,7 +62,7 @@ class ResourceNewsListParser implements ParserInterface
     public function getHasNextPage(): bool
     {
         $pages = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[1]/a[contains(text(), "More News")]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div[1]/a[contains(text(), "More News")]');
 
         if ($pages->count()) {
             return true;

--- a/src/Parser/Person/PersonParser.php
+++ b/src/Parser/Person/PersonParser.php
@@ -114,7 +114,7 @@ class PersonParser implements ParserInterface
     public function getPersonFamilyName(): ?string
     {
         $node = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]/span[text()="Family name:"]');
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]/span[text()="Family name:"]');
 
         if (!$node->count()) {
             return null;
@@ -147,7 +147,7 @@ class PersonParser implements ParserInterface
     public function getPersonAlternateNames(): array
     {
         $node = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]/div/span[text()="Alternate names:"]');
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]/div/span[text()="Alternate names:"]');
 
         if (!$node->count()) {
             return [];
@@ -173,7 +173,7 @@ class PersonParser implements ParserInterface
     public function getPersonWebsite(): ?string
     {
         $node = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]/span[text()="Website:"]');
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]/span[text()="Website:"]');
 
 
         $website = $node->nextAll()->filter('a');
@@ -240,7 +240,7 @@ class PersonParser implements ParserInterface
     public function getPersonAbout(): ?string
     {
         $node = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[@class="borderClass"]')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[@class="borderClass"]')
             ->filter('.people-informantion-more');
 
         if (!$node->count()) {
@@ -265,7 +265,7 @@ class PersonParser implements ParserInterface
     public function getPersonVoiceActingRoles(): array
     {
         $node = $this->crawler
-            ->filterXPath('//table[contains(@class, "js-table-people-character")]/tr[contains(@class, "js-people-character")]');
+            ->filterXPath('//table[contains(@class, "js-table-people-character")]/tbody/tr[contains(@class, "js-people-character")]');
 
         if (!$node->count()) {
             return [];
@@ -286,7 +286,7 @@ class PersonParser implements ParserInterface
     public function getPersonAnimeStaffPositions(): array
     {
         $node = $this->crawler
-            ->filterXPath('//table[contains(@class, "js-table-people-staff")]/tr[contains(@class, "js-people-staff")]');
+            ->filterXPath('//table[contains(@class, "js-table-people-staff")]/tbody/tr[contains(@class, "js-people-staff")]');
 
         if (!$node->count()) {
             return [];

--- a/src/Parser/Recommendations/RecommendationListItemParser.php
+++ b/src/Parser/Recommendations/RecommendationListItemParser.php
@@ -45,7 +45,7 @@ class RecommendationListItemParser implements ParserInterface
     public function getRecommendations(): array
     {
         return $this->crawler
-            ->filterXPath('//table/tr/td')
+            ->filterXPath('//table/tbody/tr/td')
             ->each(function (Crawler $crawler) {
                 return new Model\Common\CommonMeta(
                     $crawler->filterXPath('//a/strong')->text(),

--- a/src/Parser/Reviews/AnimeReviewParser.php
+++ b/src/Parser/Reviews/AnimeReviewParser.php
@@ -149,19 +149,19 @@ class AnimeReviewParser implements ParserInterface
         return 0; //@todo replace with reactions array
 
         // works on Profile pages
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tr/td[1]/div/strong/span');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td[1]/div/strong/span');
         if ($node->count()) {
             return $node->text();
         }
 
         // works on Anime/Manga Review pages
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[2]/table/tr/td[2]/div/strong/span');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[2]/table/tbody/tr/td[2]/div/strong/span');
         if ($node->count()) {
             return $node->text();
         }
 
         // works on Top UserReviewsParser pages, the div is shifted
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tr/td[2]/div/strong/span');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td[2]/div/strong/span');
         return $node->text();
     }
 

--- a/src/Parser/Reviews/MangaReviewParser.php
+++ b/src/Parser/Reviews/MangaReviewParser.php
@@ -93,19 +93,19 @@ class MangaReviewParser implements ParserInterface
     public function getHelpfulCount(): int
     {
         // works on Anime/Manga Review pages
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[2]/table/tr/td[2]/div/strong/span');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[2]/table/tbody/tr/td[2]/div/strong/span');
         if ($node->count()) {
             return $node->text();
         }
 
         // works on Top UserReviewsParser pages, the div is shifted
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tr/td[2]/div/strong/span');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td[2]/div/strong/span');
         if ($node->count()) {
             return $node->text();
         }
 
         // works on User UserReviews pages
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tr/td/div/strong/span');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td/div/strong/span');
         return $node->text();
     }
 

--- a/src/Parser/Reviews/ReviewerParser.php
+++ b/src/Parser/Reviews/ReviewerParser.php
@@ -52,7 +52,7 @@ class ReviewerParser implements ParserInterface
         }
 
         // works on Top UserReviewsParser pages, the div is shifted
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tr/td[2]/a');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td[2]/a');
         if ($node->count()) {
             return $node->attr('href');
         }
@@ -74,7 +74,7 @@ class ReviewerParser implements ParserInterface
 
         // works on Top UserReviewsParser pages, the div is shifted
         return $this->crawler
-            ->filterXPath('//div[1]/div[1]/div[4]/table/tr/td[2]/a')
+            ->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td[2]/a')
             ->text();
     }
 
@@ -93,7 +93,7 @@ class ReviewerParser implements ParserInterface
         }
 
         // works on Top UserReviewsParser pages, the div is shifted
-        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tr/td[1]/div/a/img');
+        $node = $this->crawler->filterXPath('//div[1]/div[1]/div[4]/table/tbody/tr/td[1]/div/a/img');
         return Parser::parseImageThumbToHQ(
             $node
                 ->attr('src')

--- a/src/Parser/Search/AnimeSearchParser.php
+++ b/src/Parser/Search/AnimeSearchParser.php
@@ -48,7 +48,7 @@ class AnimeSearchParser
     public function getResults(): array
     {
         $results = $this->crawler
-            ->filterXPath('//div[contains(@class, "js-categories-seasonal")]/table/tr[1]');
+            ->filterXPath('//div[contains(@class, "js-categories-seasonal")]/table/tbody/tr[1]');
 
         if (!$results->count()) {
             return [];

--- a/src/Parser/Search/CharacterSearchParser.php
+++ b/src/Parser/Search/CharacterSearchParser.php
@@ -46,14 +46,14 @@ class CharacterSearchParser
     public function getResults(): array
     {
         $probrem = $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr/td[1][contains(text(), "There were some probrems")]');
+            ->filterXPath('//div[@id="content"]/table/tbody/tr/td[1][contains(text(), "There were some probrems")]');
 
         if ($probrem->count()) {
             return [];
         }
 
         return $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr')
             ->each(
                 function (Crawler $c) {
                     return new CharacterSearchListItemParser($c)->getModel();

--- a/src/Parser/Search/MangaSearchParser.php
+++ b/src/Parser/Search/MangaSearchParser.php
@@ -48,7 +48,7 @@ class MangaSearchParser
     public function getResults(): array
     {
         $results = $this->crawler
-            ->filterXPath('//div[contains(@class, "js-categories-seasonal")]/table/tr[1]');
+            ->filterXPath('//div[contains(@class, "js-categories-seasonal")]/table/tbody/tr[1]');
 
         if (!$results->count()) {
             return [];

--- a/src/Parser/Search/PersonSearchParser.php
+++ b/src/Parser/Search/PersonSearchParser.php
@@ -64,7 +64,7 @@ class PersonSearchParser
         }
 
         return $this->crawler
-            ->filterXPath('//div[@id="content"]/table/tr')
+            ->filterXPath('//div[@id="content"]/table/tbody/tr')
             ->each(
                 function (Crawler $c) {
                     return new PersonSearchListItemParser($c)->getModel();

--- a/src/Parser/Search/UserSearchParser.php
+++ b/src/Parser/Search/UserSearchParser.php
@@ -51,12 +51,12 @@ class UserSearchParser
         // Check if it's the main page
         // For `getRecentlyOnlineUsers`
         $node = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[1]/table/tr/td');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[1]/table/tbody/tr/td');
 
         // User search page
         if (!$node->count()) {
             $node = $this->crawler
-                ->filterXPath('//*[@id="content"]/table/tr/td');
+                ->filterXPath('//*[@id="content"]/table/tbody/tr/td');
         }
 
         $data = $node

--- a/src/Parser/User/ClubParser.php
+++ b/src/Parser/User/ClubParser.php
@@ -36,7 +36,7 @@ class ClubParser
     public function getClubs(): array
     {
         $node = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/ol/li');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/ol/li');
 
         return $node->each(function (Crawler $crawler) {
             return Model\Common\ClubMeta::factory(

--- a/src/Parser/User/Friends/FriendsParser.php
+++ b/src/Parser/User/Friends/FriendsParser.php
@@ -58,7 +58,7 @@ class FriendsParser implements ParserInterface
     public function getLastPage(): int
     {
         $pages = $this->crawler
-            ->filterXPath('//*[@id="content"]/table/tr/td[2]/div[2]/div[contains(@class, "mt12 mb12")]/div[contains(@class, "pagination")]');
+            ->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]/div[2]/div[contains(@class, "mt12 mb12")]/div[contains(@class, "pagination")]');
 
         if (!$pages->count()) {
             return 1;

--- a/src/Parser/User/History/HistoryParser.php
+++ b/src/Parser/User/History/HistoryParser.php
@@ -35,7 +35,7 @@ class HistoryParser implements ParserInterface
      */
     public function getModel(): array
     {
-        $node = $this->crawler->filterXPath('//div[@id="content"]/div/table/tr');
+        $node = $this->crawler->filterXPath('//div[@id="content"]/div/table/tbody/tr');
 
         return $node
             ->reduce(

--- a/src/Parser/User/Profile/UserProfileParser.php
+++ b/src/Parser/User/Profile/UserProfileParser.php
@@ -195,7 +195,7 @@ class UserProfileParser
      */
     public function getAbout(): ?string
     {
-        $about = $this->crawler->filterXPath('//div[@class=\'profile-about-user js-truncate-inner\']/table/tr/td/div');
+        $about = $this->crawler->filterXPath('//div[@class=\'profile-about-user js-truncate-inner\']/table/tbody/tr/td/div');
 
 
         if (!$about->count()) {

--- a/src/Parser/User/Reviews/UserReviewsParser.php
+++ b/src/Parser/User/Reviews/UserReviewsParser.php
@@ -36,7 +36,7 @@ class UserReviewsParser
 
     public function getReviews(): array
     {
-        $node = $this->crawler->filterXPath('//*[@id="content"]/table/tr/td[2]//div[contains(@class, "review-element")]');
+        $node = $this->crawler->filterXPath('//*[@id="content"]/table/tbody/tr/td[2]//div[contains(@class, "review-element")]');
 
         if (!$node->count()) {
             return [];

--- a/test/unit/Parser/Anime/AnimeParserTest.php
+++ b/test/unit/Parser/Anime/AnimeParserTest.php
@@ -305,7 +305,7 @@ class AnimeParserTest extends TestCase
     public function it_gets_the_anime_opening(): void
     {
         $ops = $this->parser->getOpeningThemes();
-        self::assertCount(1, $ops);
+        self::assertCount(3, $ops);
         self::assertContains('"H.T." by Tsuneo Imahori', $ops);
     }
 
@@ -321,7 +321,7 @@ class AnimeParserTest extends TestCase
     public function it_gets_the_preview_video()
     {
         $preview = $this->parser->getPreview();
-        self::assertEquals('https://www.youtube.com/embed/bJVyIXeUznY?enablejsapi=1&wmode=opaque&autoplay=1', $preview);
+        self::assertEquals('https://www.youtube-nocookie.com/embed/bJVyIXeUznY?enablejsapi=1&wmode=opaque&autoplay=1', $preview);
     }
 
     #[Test]

--- a/test/unit/Parser/Character/AnimeographyParserTest.php
+++ b/test/unit/Parser/Character/AnimeographyParserTest.php
@@ -22,7 +22,7 @@ class AnimeographyParserTest extends TestCase
 
         $client = new HttpClientWrapper($this->httpClient);
         $crawler = $client->request('GET', 'https://myanimelist.net/character/116281');
-        $crawler = $crawler->filterXPath('//div[contains(text(), \'Animeography\')]/../table/tr')->first();
+        $crawler = $crawler->filterXPath('//div[contains(text(), \'Animeography\')]/../table/tbody/tr')->first();
         $this->parser = new \Jikan\Parser\Character\AnimeographyParser($crawler);
     }
 

--- a/test/unit/Parser/Character/VoiceActorParserTest.php
+++ b/test/unit/Parser/Character/VoiceActorParserTest.php
@@ -22,7 +22,7 @@ class VoiceActorParserTest extends TestCase
 
         $client = new HttpClientWrapper($this->httpClient);
         $crawler = $client->request('GET', 'https://myanimelist.net/character/116281');
-        $crawler = $crawler->filterXPath('//div[contains(text(), \'Voice Actors\')]/../table/tr')->first();
+        $crawler = $crawler->filterXPath('//div[contains(text(), \'Voice Actors\')]/../table/tbody/tr')->first();
         $this->parser = new \Jikan\Parser\Character\VoiceActorParser($crawler);
     }
 

--- a/test/unit/Parser/Manga/MangaParserTest.php
+++ b/test/unit/Parser/Manga/MangaParserTest.php
@@ -258,7 +258,7 @@ class MangaParserTest extends TestCase
     public function it_gets_the_manga_related()
     {
         $related = $this->parser->getMangaRelated();
-        self::assertCount(6, $related);
+        self::assertCount(2, $related);
         self::assertContainsOnlyInstancesOf(MalUrl::class, $related['Adaptation']);
     }
 

--- a/test/unit/Parser/SeasonList/SeasonListItemParserTest.php
+++ b/test/unit/Parser/SeasonList/SeasonListItemParserTest.php
@@ -20,9 +20,7 @@ class SeasonListItemParserTest extends TestCase
 
         $client = new HttpClientWrapper($this->httpClient);
         $crawler = $client->request('GET', 'https://myanimelist.net/anime/season/archive');
-        $this->parser = new SeasonListItemParser(
-            $crawler->filterXPath('//table[contains(@class, "anime-seasonal-byseason")]/tr')->first()
-        );
+        $this->parser = new SeasonListItemParser($crawler);
     }
 
     #[Test]


### PR DESCRIPTION
- Symfony 7.4+, 8+ uses PHP's native html5 parser
- MAL's HTML when it comes to tables doesn't follow HTML semantically, so there's no `tbody`  element.
- The native HTML5 parser inserts that into the DOM
- So previous selectors like  `//table[contains(@class, "entries-table")]/tr` do not work and require tbody in there `'//table[contains(@class, "entries-table")]/tbody/tr`
- Most of the changes were in this apart from a few

Fixes: https://github.com/jikan-me/jikan/issues/575 https://github.com/jikan-me/jikan/issues/574